### PR TITLE
Update addon API docs

### DIFF
--- a/assets/assets/css/docs/base.scss
+++ b/assets/assets/css/docs/base.scss
@@ -171,6 +171,10 @@ article {
 			padding: 6px 13px;
 			border: 1px solid $bs-gray-300;
 		}
+
+		tr > th:empty {
+			display: none;
+		}
 	
 		tr {
 			border-top: 1px solid darken($bs-gray-300, 4%);

--- a/content/docs/reference/addon-api/_index.md
+++ b/content/docs/reference/addon-api/_index.md
@@ -1,8 +1,8 @@
 ---
 title: Addon API
-description: This API can be used within your addons, which can provide useful things such as access to the real blockly, Scratch's vm, etc.
+description: The `addon.*` API allows JavaScript addon code to obtain Scratch-related information (for example, get the current logged in user) and also use extension APIs (like sending notifications).
 aliases: 
   - /docs/developing/addon-apis-reference
 ---
 
-This API can be used within your addons, which can provide useful things such as access to the real Blockly, Scratch's VM, etc.
+The `addon.*` API allows JavaScript addon code to obtain Scratch-related information (for example, get the current logged in user) and also use extension APIs (like sending notifications).

--- a/content/docs/reference/addon-api/addon.account.md
+++ b/content/docs/reference/addon-api/addon.account.md
@@ -22,9 +22,15 @@ Allows addons to execute actions in the currently logged in Scratch user.
   </tr>
 </table>
 
-Returns a promise that resolves to an integer (the unread message count for the currently logged in user), or `null`.
+Gets the unread message count of the currently logged in user.  
+The promise will resolve to `null` if `addon.auth.isLoggedIn` is `false`.
 
 ### getMessages
+
+| | |
+|-|-|
+| Available in userscripts | ❌ |
+
 <table>
   <tr>
     <th>Parameter</th>
@@ -64,7 +70,21 @@ Returns a promise that resolves to an integer (the unread message count for the 
   </tr>
 </table>
 
-**NOT available in userscripts!! Not recommended for general use. This method exists to avoid duplicated work between Scratch Notifier and Scratch Messaging.**  
+Gets recent Scratch messages of the currently logged in user.  
+The promise will resolve to `null` if `addon.auth.isLoggedIn` is `false`.  
+Can only return up to 40 messages at a time.
 
-`opts`: object with an `offset` property, default is 0. Messages limit is always 40.  
-Returns a promise that resolves to the requested messages, or `null` if something failed.
+### clearMessages
+
+| | |
+|-|-|
+| Available in userscripts | ❌ |
+
+<table>
+  <tr>
+    <td>Return value</td>
+    <td><code>Promise&lt;void></code></td>
+  </tr>
+</table>
+
+Clears the unread message count of the currently logged in user.  

--- a/content/docs/reference/addon-api/addon.account.md
+++ b/content/docs/reference/addon-api/addon.account.md
@@ -4,8 +4,11 @@ description: Allows addons to execute actions in the currently logged in Scratch
 weight: 4
 ---
 
-**Available in persistent scripts.**  
-**Available in userscripts.**
+| | |
+|-|-|
+| Available in userscripts | ✔️ |
+| Available in persistent scripts | ✔️ |
+| Required manifest permissions | None |
 
 Allows addons to execute actions in the currently logged in Scratch user.
 

--- a/content/docs/reference/addon-api/addon.account.md
+++ b/content/docs/reference/addon-api/addon.account.md
@@ -14,9 +14,57 @@ weight: 4
 Allows addons to execute actions in the currently logged in Scratch user.
 
 ## Methods
-### getMsgCount()
+### getMsgCount
+<table>
+  <tr>
+    <td>Return value</td>
+    <td><code>Promise&lt;Number | null></code></td>
+  </tr>
+</table>
+
 Returns a promise that resolves to an integer (the unread message count for the currently logged in user), or `null`.
-### getMessages(opts)
+
+### getMessages
+<table>
+  <tr>
+    <th>Parameter</th>
+    <th>Type</th>
+    <th>Required</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>opts</td>
+    <td><code>Object</code></td>
+    <td>No</td>
+    <td>
+      <table>
+        <tr>
+          <th>Property</th>
+          <th>Type</th>
+          <th>Required</th>
+          <th>Default</th>
+          <th>Description</th>
+        </tr>
+        <tr>
+          <td>offset</td>
+          <td><code>Number</code></td>
+          <td>No</td>
+          <td><code>0</code></td>
+          <td>Offset to use when requesting to Scratch API.</td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>
+
+<table>
+  <tr>
+    <td>Return value</td>
+    <td><code>Promise&lt;ScratchApiMessage[] | null></code></td>
+  </tr>
+</table>
+
 **NOT available in userscripts!! Not recommended for general use. This method exists to avoid duplicated work between Scratch Notifier and Scratch Messaging.**  
+
 `opts`: object with an `offset` property, default is 0. Messages limit is always 40.  
 Returns a promise that resolves to the requested messages, or `null` if something failed.

--- a/content/docs/reference/addon-api/addon.account.md
+++ b/content/docs/reference/addon-api/addon.account.md
@@ -13,7 +13,7 @@ weight: 4
 ## Description
 Allows addons to execute actions in the currently logged in Scratch user.
 
-## Functions
+## Methods
 ### getMsgCount()
 Returns a promise that resolves to an integer (the unread message count for the currently logged in user), or `null`.
 ### getMessages(opts)

--- a/content/docs/reference/addon-api/addon.account.md
+++ b/content/docs/reference/addon-api/addon.account.md
@@ -10,6 +10,7 @@ weight: 4
 | Available in persistent scripts | ✔️ |
 | Required manifest permissions | None |
 
+## Description
 Allows addons to execute actions in the currently logged in Scratch user.
 
 ## Functions

--- a/content/docs/reference/addon-api/addon.auth.md
+++ b/content/docs/reference/addon-api/addon.auth.md
@@ -1,5 +1,5 @@
 ---
-title: addon.self
+title: addon.auth
 description: Allows addons to get information about the current Scratch account session.
 weight: 3
 ---

--- a/content/docs/reference/addon-api/addon.auth.md
+++ b/content/docs/reference/addon-api/addon.auth.md
@@ -13,7 +13,7 @@ weight: 3
 ## Description
 Allows addons to get information about the current Scratch account session.
 
-## Getters
+## Properties
 ### addon.auth.scratchLang (string)
 Returns the language code for the language choice the user has made in Scratch, for example. `"en"`.  
 Keep in mind that this property is unrelated from all the others - this getter is inside `addon.auth` because it involves reading Scratch cookies. The change of this value **will not** trigger a "change" event.
@@ -30,7 +30,7 @@ Returns the value of the `scratchcsrftoken` cookie.
 
 ## Events
 ### change
-Fires when any of the getters change (except scratchLang).  
+Fires when any of the properties change (except scratchLang).  
 #### Example:
 ```js
 addon.auth.addEventListener("change", function() {

--- a/content/docs/reference/addon-api/addon.auth.md
+++ b/content/docs/reference/addon-api/addon.auth.md
@@ -13,6 +13,14 @@ weight: 3
 ## Description
 Allows addons to get information about the current Scratch account session.
 
+## Examples
+### Reacting to auth info change
+```js
+addon.auth.addEventListener("change", function() {
+  console.log(addon.auth.isLoggedIn);
+});
+```
+
 ## Properties
 ### addon.auth.scratchLang
 <table>
@@ -101,10 +109,4 @@ Returns the value of the `scratchcsrftoken` cookie.
 
 ## Events
 ### change
-Fires when any of the properties change (except scratchLang).  
-#### Example:
-```js
-addon.auth.addEventListener("change", function() {
-  console.log(addon.auth.isLoggedIn);
-});
-```
+Fires when any of the properties change (except scratchLang).

--- a/content/docs/reference/addon-api/addon.auth.md
+++ b/content/docs/reference/addon-api/addon.auth.md
@@ -4,8 +4,11 @@ description: Allows addons to get information about the current Scratch account 
 weight: 3
 ---
 
-**Available in persistent scripts.**  
-**Available in userscripts.**
+| | |
+|-|-|
+| Available in userscripts | ✔️ |
+| Available in persistent scripts | ✔️ |
+| Required manifest permissions | None |
 
 Allows addons to get information about the current Scratch account session.
 

--- a/content/docs/reference/addon-api/addon.auth.md
+++ b/content/docs/reference/addon-api/addon.auth.md
@@ -34,8 +34,9 @@ addon.auth.addEventListener("change", function() {
   </tr>
 </table>
 
-Returns the language code for the language choice the user has made in Scratch, for example. `"en"`.  
-Keep in mind that this property is unrelated from all the others - this getter is inside `addon.auth` because it involves reading Scratch cookies. The change of this value **will not** trigger a "change" event.
+Language of the Scratch website.  
+This language option can be changed by the user in the footer of Scratch's website.  
+This property changing does not fire a `change` event.
 
 ### addon.auth.isLoggedIn
 <table>
@@ -49,7 +50,7 @@ Keep in mind that this property is unrelated from all the others - this getter i
   </tr>
 </table>
 
-Returns whether the user is logged in or not. If `false`, all below return `null`.
+Whether the user is logged in or not.
 
 ### addon.auth.username
 <table>
@@ -63,7 +64,8 @@ Returns whether the user is logged in or not. If `false`, all below return `null
   </tr>
 </table>
 
-Returns the username of the currently logged in user.
+Username of the currently logged in user.  
+Will be `null` if `addon.auth.isLoggedIn` is `false`.
 
 ### addon.auth.userId
 <table>
@@ -77,7 +79,8 @@ Returns the username of the currently logged in user.
   </tr>
 </table>
 
-Returns the user ID of the currently logged in user.
+User ID of the currently logged in user.  
+Will be `null` if `addon.auth.isLoggedIn` is `false`.
 
 ### addon.auth.xToken
 <table>
@@ -91,7 +94,8 @@ Returns the user ID of the currently logged in user.
   </tr>
 </table>
 
-Returns the value of the `X-Token` header used in the Scratch REST API.
+Value of the `X-Token` header used in the Scratch REST API.  
+Will be `null` if `addon.auth.isLoggedIn` is `false`.
 
 ### addon.auth.csrfToken
 <table>
@@ -105,8 +109,9 @@ Returns the value of the `X-Token` header used in the Scratch REST API.
   </tr>
 </table>
 
-Returns the value of the `scratchcsrftoken` cookie.
+Value of the `scratchcsrftoken` cookie.  
+Will be `null` if `addon.auth.isLoggedIn` is `false`.
 
 ## Events
 ### change
-Fires when any of the properties change (except scratchLang).
+Fires when any of `isLoggedIn`, `username`, `userId`, `xToken` or `csrfToken` change.

--- a/content/docs/reference/addon-api/addon.auth.md
+++ b/content/docs/reference/addon-api/addon.auth.md
@@ -10,6 +10,7 @@ weight: 3
 | Available in persistent scripts | ✔️ |
 | Required manifest permissions | None |
 
+## Description
 Allows addons to get information about the current Scratch account session.
 
 ## Getters

--- a/content/docs/reference/addon-api/addon.auth.md
+++ b/content/docs/reference/addon-api/addon.auth.md
@@ -14,18 +14,89 @@ weight: 3
 Allows addons to get information about the current Scratch account session.
 
 ## Properties
-### addon.auth.scratchLang (string)
+### addon.auth.scratchLang
+<table>
+  <tr>
+    <td>Type</td>
+    <td><code>String</code></td>
+  </tr>
+  <tr>
+    <td>Nullable</td>
+    <td>No</td> 
+  </tr>
+</table>
+
 Returns the language code for the language choice the user has made in Scratch, for example. `"en"`.  
 Keep in mind that this property is unrelated from all the others - this getter is inside `addon.auth` because it involves reading Scratch cookies. The change of this value **will not** trigger a "change" event.
-### addon.auth.isLoggedIn (boolean)
+
+### addon.auth.isLoggedIn
+<table>
+  <tr>
+    <td>Type</td>
+    <td><code>Boolean</code></td>
+  </tr>
+  <tr>
+    <td>Nullable</td>
+    <td>No</td> 
+  </tr>
+</table>
+
 Returns whether the user is logged in or not. If `false`, all below return `null`.
-### addon.auth.username (string)
+
+### addon.auth.username
+<table>
+  <tr>
+    <td>Type</td>
+    <td><code>String</code></td>
+  </tr>
+  <tr>
+    <td>Nullable</td>
+    <td>Yes</td> 
+  </tr>
+</table>
+
 Returns the username of the currently logged in user.
-### addon.auth.userId (string)
+
+### addon.auth.userId
+<table>
+  <tr>
+    <td>Type</td>
+    <td><code>Number</code></td>
+  </tr>
+  <tr>
+    <td>Nullable</td>
+    <td>Yes</td> 
+  </tr>
+</table>
+
 Returns the user ID of the currently logged in user.
-### addon.auth.xToken (string)
+
+### addon.auth.xToken
+<table>
+  <tr>
+    <td>Type</td>
+    <td><code>String</code></td>
+  </tr>
+  <tr>
+    <td>Nullable</td>
+    <td>Yes</td> 
+  </tr>
+</table>
+
 Returns the value of the `X-Token` header used in the Scratch REST API.
-### addon.auth.csrfToken (string)
+
+### addon.auth.csrfToken
+<table>
+  <tr>
+    <td>Type</td>
+    <td><code>String</code></td>
+  </tr>
+  <tr>
+    <td>Nullable</td>
+    <td>Yes</td> 
+  </tr>
+</table>
+
 Returns the value of the `scratchcsrftoken` cookie.
 
 ## Events

--- a/content/docs/reference/addon-api/addon.badge.md
+++ b/content/docs/reference/addon-api/addon.badge.md
@@ -6,9 +6,11 @@ weight: 7
 
 **Keep in mind: only one addon (currently `msg-count-badge`) can use the badge API.**
 
-**Available in persistent scripts.**  
-**NOT available in userscripts.**  
-**Required permissions: `badge`**  
+| | |
+|-|-|
+| Available in userscripts | ❌ |
+| Available in persistent scripts | ✔️ |
+| Required manifest permissions | `badge` |
 
 Allows addons to display a badge, a bit of text that is layered over the extension icon, frequently a number.
 

--- a/content/docs/reference/addon-api/addon.badge.md
+++ b/content/docs/reference/addon-api/addon.badge.md
@@ -10,17 +10,17 @@ weight: 7
 | Available in persistent scripts | ✔️ |
 | Required manifest permissions | `badge` |
 
+> _**Note: currently only one addon (`msg-count-badge`) can use this API. Do not use it in your addon without discussing on GitHub first.**_
+
 ## Description
 Allows addons to display a badge, a bit of text that is layered over the extension icon, frequently a number.
 
-**Keep in mind: only one addon (currently `msg-count-badge`) can use the badge API.**
-
 ## Getters & setters
 ### addon.badge.text
-Allows addons to set the text on the badge.  
-Accepts numbers, which are automatically converted to strings.  
-`null` and `0` are considered as empty strings.  
-If the badge is set to an empty string, it won't be displayed.
+Text shown on the badge.  
+Numbers are automatically converted to strings.  
+If this is set to `""`, `null` or `0`, the badge will be hidden.
+
 ### addon.badge.color
-Allows addons to set the color of the badge.
+Color of the badge.  
 Accepts any CSS supported color.

--- a/content/docs/reference/addon-api/addon.badge.md
+++ b/content/docs/reference/addon-api/addon.badge.md
@@ -4,15 +4,16 @@ description: Allows addons to display a badge, a bit of text that is layered ove
 weight: 7
 ---
 
-**Keep in mind: only one addon (currently `msg-count-badge`) can use the badge API.**
-
 | | |
 |-|-|
 | Available in userscripts | ❌ |
 | Available in persistent scripts | ✔️ |
 | Required manifest permissions | `badge` |
 
+## Description
 Allows addons to display a badge, a bit of text that is layered over the extension icon, frequently a number.
+
+**Keep in mind: only one addon (currently `msg-count-badge`) can use the badge API.**
 
 ## Getters & setters
 ### addon.badge.text

--- a/content/docs/reference/addon-api/addon.notifications.md
+++ b/content/docs/reference/addon-api/addon.notifications.md
@@ -13,6 +13,37 @@ weight: 6
 ## Description
 Allows addons to create browser notifications. This API slightly differs from the `browser.notifications` API extensions can use.
 
+## Example
+### General example
+```js
+addon.notifications.create({
+  type: "basic",
+  title: "Hello from notification!",
+  iconUrl: "/images/icon.png",
+  message: "Hi!",
+  buttons: [
+    {
+      title: "Button 1",
+    },
+    {
+      title: "Button 2",
+    },
+  ],
+});
+
+addon.notifications.addEventListener("click", function(event) {
+  console.log("User clicked notification with ID " + event.detail.id);
+});
+addon.notifications.addEventListener("closed", function(event) {
+  console.log("User closed notification with ID " + event.detail.id);
+});
+addon.notifications.addEventListener("buttonclick", function(event) {
+  console.log(`User clicked button ${event.detail.buttonIndex} of notification ${event.detail.id}`);
+});
+
+```
+
+
 ## Properties
 ### addon.notifications.muted
 
@@ -53,10 +84,8 @@ Whether Scratch Addons is currently muted or not.
   </tr>
 </table>
 
-Returns a promise that resolves to the ID (string) of the created notification.  
-Shows a notification to the user according to the options object.  
-[Options object reference](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/notifications/NotificationOptions).  
-Note: for your convenience, specifying `buttons` or `requireInteraction` throws on Firefox.
+Creates a notification.  
+The notification will not be created if Scratch Addons is muted.
 
 ### addon.notifications.update
 <table>
@@ -86,8 +115,8 @@ Note: for your convenience, specifying `buttons` or `requireInteraction` throws 
   </tr>
 </table>
 
-Returns a promise that resolves to `true` if succeeded, `false` if not.  
-Updates a notification, given its ID.
+Updates an existing notification, given its ID.  
+The returned promise resolves to a boolean that indicates whether the update succeeded.  
 
 ### addon.notifications.clear
 <table>
@@ -112,8 +141,8 @@ Updates a notification, given its ID.
   </tr>
 </table>
 
-Returns a promise that resolves to `true` if succeeded, `false` if not.  
-Clears a notification, given its ID.
+Clears an existing notification, given its ID.  
+The returned promise resolves to a boolean that indicates whether the clearing succeeded.
 
 ### addon.notifications.getAll
 <table>
@@ -122,7 +151,9 @@ Clears a notification, given its ID.
     <td><code>Object[]</code></td>
   </tr>
 </table>
-Returns a promise that resolves to all currently active notifications created by the addon.
+
+Gets all existing notifications for the addon.  
+Based on <code><a href="https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/notifications/getAll" target="_blank">browser.notifications.getAll()</a></code>.
 
 ## Events
 ### click
@@ -139,14 +170,7 @@ Returns a promise that resolves to all currently active notifications created by
   </tr>
 </table>
 
-Fires when any notification by the addon is clicked.  
-`event.detail.id` is provided, which specifies which notification has been clicked.
-#### Example:
-```js
-addon.notifications.addEventListener("click", function(event) {
-  console.log("User clicked notification with ID " + event.detail.id);
-});
-```
+Fires when any existing notification is clicked.
 
 ### close
 <table>
@@ -162,8 +186,7 @@ addon.notifications.addEventListener("click", function(event) {
   </tr>
 </table>
 
-Fires when any notification by the addon is clicked.  
-`event.detail.id` is provided, which specifies which notification has been closed.
+Fires when any existing notification is closed.
 
 ### buttonclick
 <table>
@@ -184,7 +207,5 @@ Fires when any notification by the addon is clicked.
   </tr>
 </table>
 
-Fires when a button inside a notification by the addon is clicked.  
-`event.detail.id` is provided, which specifies which notification received a button click.  
-`event.details.buttonIndex` returns the index of the button that was clicked (first button has index of 0).  
-Registering this event on Firefox won't throw.
+Fires when a notification button is clicked.  
+This will never fire in Firefox.

--- a/content/docs/reference/addon-api/addon.notifications.md
+++ b/content/docs/reference/addon-api/addon.notifications.md
@@ -4,9 +4,11 @@ description: Allows addons to create browser notifications. This API slightly di
 weight: 6
 ---
 
-**Available in persistent scripts.**  
-**NOT available in userscripts.**  
-**Required permissions: `notifications`**
+| | |
+|-|-|
+| Available in userscripts | ❌ |
+| Available in persistent scripts | ✔️ |
+| Required manifest permissions | `notifications` |
 
 Allows addons to create browser notifications. This API slightly differs from the `browser.notifications` API extensions can use.
 

--- a/content/docs/reference/addon-api/addon.notifications.md
+++ b/content/docs/reference/addon-api/addon.notifications.md
@@ -13,6 +13,22 @@ weight: 6
 ## Description
 Allows addons to create browser notifications. This API slightly differs from the `browser.notifications` API extensions can use.
 
+## Properties
+### addon.notifications.muted
+
+<table>
+  <tr>
+    <td>Type</td>
+    <td><code>Boolean</code></td>
+  </tr>
+  <tr>
+    <td>Nullable</td>
+    <td>No</td> 
+  </tr>
+</table>
+
+Whether Scratch Addons is currently muted or not.
+
 ## Methods
 ### addon.notifications.create
 <table>

--- a/content/docs/reference/addon-api/addon.notifications.md
+++ b/content/docs/reference/addon-api/addon.notifications.md
@@ -110,6 +110,19 @@ Returns a promise that resolves to all currently active notifications created by
 
 ## Events
 ### click
+<table>
+  <tr>
+    <th>Event detail property</th>
+    <th>Type</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>id</td>
+    <td><code>String</code></td>
+    <td>The ID of the notification that was clicked</td>
+  </tr>
+</table>
+
 Fires when any notification by the addon is clicked.  
 `event.detail.id` is provided, which specifies which notification has been clicked.
 #### Example:
@@ -118,10 +131,43 @@ addon.notifications.addEventListener("click", function(event) {
   console.log("User clicked notification with ID " + event.detail.id);
 });
 ```
+
 ### close
+<table>
+  <tr>
+    <th>Event detail property</th>
+    <th>Type</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>id</td>
+    <td><code>String</code></td>
+    <td>The ID of the notification that was closed</td>
+  </tr>
+</table>
+
 Fires when any notification by the addon is clicked.  
 `event.detail.id` is provided, which specifies which notification has been closed.
+
 ### buttonclick
+<table>
+  <tr>
+    <th>Event detail property</th>
+    <th>Type</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>id</td>
+    <td><code>String</code></td>
+    <td>The ID of the notification where a button was clicked</td>
+  </tr>
+  <tr>
+    <td>buttonIndex</td>
+    <td><code>Number</code></td>
+    <td>Index of the button that was clicked (first button being index 0)</td>
+  </tr>
+</table>
+
 Fires when a button inside a notification by the addon is clicked.  
 `event.detail.id` is provided, which specifies which notification received a button click.  
 `event.details.buttonIndex` returns the index of the button that was clicked (first button has index of 0).  

--- a/content/docs/reference/addon-api/addon.notifications.md
+++ b/content/docs/reference/addon-api/addon.notifications.md
@@ -1,5 +1,5 @@
 ---
-title: addon.account
+title: addon.notifications
 description: Allows addons to create browser notifications. This API slightly differs from the browser.notifications API extensions can use.
 weight: 6
 ---

--- a/content/docs/reference/addon-api/addon.notifications.md
+++ b/content/docs/reference/addon-api/addon.notifications.md
@@ -14,18 +14,98 @@ weight: 6
 Allows addons to create browser notifications. This API slightly differs from the `browser.notifications` API extensions can use.
 
 ## Methods
-### addon.notifications.create(optionsObject)
+### addon.notifications.create
+<table>
+  <tr>
+    <th>Parameter</th>
+    <th>Type</th>
+    <th>Required</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>options</td>
+    <td><code><a href="https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/notifications/NotificationOptions" target="_blank">NotificationOptions</a></code></td>
+    <td>Yes</td>
+    <td>Unlike the <code>browser.notifications</code> API, specifying <code>buttons</code> or <code>requireInteraction</code> does not throw in Firefox. Instead, the values are ignored.</td>
+  </tr>
+</table>
+
+<table>
+  <tr>
+    <td>Return value</td>
+    <td><code>Promise&lt;String | null></code></td>
+  </tr>
+</table>
+
 Returns a promise that resolves to the ID (string) of the created notification.  
 Shows a notification to the user according to the options object.  
 [Options object reference](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/notifications/NotificationOptions).  
 Note: for your convenience, specifying `buttons` or `requireInteraction` throws on Firefox.
-### addon.notifications.update(stringNotificationId, optionsObject)
+
+### addon.notifications.update
+<table>
+  <tr>
+    <th>Parameter</th>
+    <th>Type</th>
+    <th>Required</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>notificationId</td>
+    <td><code>String<code></td>
+    <td>Yes</td>
+    <td>The ID of the notification to update</td>
+  <tr>
+    <td>options</td>
+    <td><code><a href="https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/notifications/NotificationOptions" target="_blank">NotificationOptions</a></code></td>
+    <td>Yes</td>
+    <td>Unlike the <code>browser.notifications</code> API, specifying <code>buttons</code> or <code>requireInteraction</code> does not throw in Firefox. Instead, the values are ignored.</td>
+  </tr>
+</table>
+
+<table>
+  <tr>
+    <td>Return value</td>
+    <td><code>Boolean</code></td>
+  </tr>
+</table>
+
 Returns a promise that resolves to `true` if succeeded, `false` if not.  
 Updates a notification, given its ID.
-### addon.notifications.clear(stringNotificationId)
+
+### addon.notifications.clear
+<table>
+  <tr>
+    <th>Parameter</th>
+    <th>Type</th>
+    <th>Required</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>notificationId</td>
+    <td><code>String<code></td>
+    <td>Yes</td>
+    <td>The ID of the notification to clear</td>
+  <tr>
+</table>
+
+<table>
+  <tr>
+    <td>Return value</td>
+    <td><code>Boolean</code></td>
+  </tr>
+</table>
+
 Returns a promise that resolves to `true` if succeeded, `false` if not.  
 Clears a notification, given its ID.
-### addon.notifications.getAll()
+
+### addon.notifications.getAll
+<table>
+  <tr>
+    <td>Return value</td>
+    <td><code>Object[]</code></td>
+  </tr>
+</table>
 Returns a promise that resolves to all currently active notifications created by the addon.
 
 ## Events

--- a/content/docs/reference/addon-api/addon.notifications.md
+++ b/content/docs/reference/addon-api/addon.notifications.md
@@ -13,7 +13,7 @@ weight: 6
 ## Description
 Allows addons to create browser notifications. This API slightly differs from the `browser.notifications` API extensions can use.
 
-## Functions
+## Methods
 ### addon.notifications.create(optionsObject)
 Returns a promise that resolves to the ID (string) of the created notification.  
 Shows a notification to the user according to the options object.  

--- a/content/docs/reference/addon-api/addon.notifications.md
+++ b/content/docs/reference/addon-api/addon.notifications.md
@@ -10,6 +10,7 @@ weight: 6
 | Available in persistent scripts | ✔️ |
 | Required manifest permissions | `notifications` |
 
+## Description
 Allows addons to create browser notifications. This API slightly differs from the `browser.notifications` API extensions can use.
 
 ## Functions

--- a/content/docs/reference/addon-api/addon.self.md
+++ b/content/docs/reference/addon-api/addon.self.md
@@ -13,6 +13,31 @@ weight: 1
 ## Description
 Allows addons to get information about themselves or the browser.
 
+## Examples
+### Using addon.self.dir
+With `addon.self.dir`, we can get the URL to an image inside the addon's directory.
+```js
+  const img = document.createElement("img");
+  img.src = addon.self.dir + "/image.svg"; 
+  // Will be something like `chrome-extension://aeepldbjfoihffgcaejikpoeppffnlbd/addons/addon-id/image.svg`
+  document.body.appendChild(img);
+```
+
+### Using addon.self.disabled and events (dynamicDisable)
+We use the `disabled` and `reenabled` events to hide the image when the addon is disabled, without
+requiring the user to refresh the page.  
+We also use `addon.self.disabled` inside an event listener to avoid running code while the addon is disabled.  
+This example requires `{"dynamicDisable": true}` in the manifest.
+```js
+  addon.self.addEventListener("disabled", () => img.style.visibility = "visible");
+  addon.self.addEventListener("reenabled", () => img.style.visibility = "hidden");
+
+  img.onclick = () => {
+    if (addon.self.disabled) return;
+    // Code starting here will only run if the image is visible
+  };
+```
+
 ## Properties
 ### addon.self.id
 <table>
@@ -26,7 +51,8 @@ Allows addons to get information about themselves or the browser.
   </tr>
 </table>
 
-The ID of the addon, in other words, the name of the folder.
+The addon ID for this addon.  
+The addon ID is the name of the directory inside `/addons` that identifies the addon.
 
 ### addon.self.dir
 <table>
@@ -40,7 +66,8 @@ The ID of the addon, in other words, the name of the folder.
   </tr>
 </table>
 
-The directory where the addon resides.
+Path to the addon's directory, without trailing slash.  
+Should be used instead of hardcoding URLs. Locally, using a hardcoded URL like `chrome-extension://aeepldbjfoihffgcaejikpoeppffnlbd/addons/full-signature/happen.js` might appear to work properly, but the extension ID can change and it will not work in Firefox.
 
 ### addon.self.lib
 <table>
@@ -54,7 +81,7 @@ The directory where the addon resides.
   </tr>
 </table>
 
-The directory where the `/libraries` folder resides.
+Path to the `/libraries` directory, without trailing slash.
 
 ### addon.self.browser
 <table>
@@ -68,7 +95,7 @@ The directory where the `/libraries` folder resides.
   </tr>
 </table>
 
-Returns either `chrome` or `firefox`, depending on the browser Scratch Addons is running at.
+The browser Scratch Addons is running on.
 
 ### addon.self.disabled
 <table>
@@ -82,7 +109,8 @@ Returns either `chrome` or `firefox`, depending on the browser Scratch Addons is
   </tr>
 </table>
 
-Whether the addon is currently disabled or not.
+Whether the addon is currently disabled or not.  
+Useful for returning early in event listeners for addons that support dynamicDisable.
 
 ### addon.self.enabledLate
 <table>
@@ -96,11 +124,16 @@ Whether the addon is currently disabled or not.
   </tr>
 </table>
 
-Returns true if the addon was dynamically enabled. Otherwise, false.
+Whether the running userscript was injected dynamically in response to the user enabling the addon.  
+Can only be `true` if the addon supports dynamicEnable.  
+If the addon was enabled when the page loaded, then was disabled and reenabled, this will still be `false`.
+In that case, the `reenabled` event will fire.
 
 ## Events
 ### disabled
-Fires when the addon gets disabled and has the `dynamicDisable` manifest property.
+Fires when the addon gets disabled.  
+Requires the `dynamicDisable` manifest property.
 
 ### reenabled
-Fires when the addon gets reenabled after being disabled.
+Fires when the addon gets reenabled, after being disabled.  
+<!-- Requires the `dynamicDisable` manifest property. -->

--- a/content/docs/reference/addon-api/addon.self.md
+++ b/content/docs/reference/addon-api/addon.self.md
@@ -4,8 +4,11 @@ description: Allows addons to get information about themselves or the browser.
 weight: 1
 ---
 
-**Available in persistent scripts.**  
-**Available in userscripts.**
+| | |
+|-|-|
+| Available in userscripts | ✔️ |
+| Available in persistent scripts | ✔️ |
+| Required manifest permissions | None |
 
 Allows addons to get information about themselves or the browser.
 

--- a/content/docs/reference/addon-api/addon.self.md
+++ b/content/docs/reference/addon-api/addon.self.md
@@ -42,6 +42,20 @@ The ID of the addon, in other words, the name of the folder.
 
 The directory where the addon resides.
 
+### addon.self.lib
+<table>
+  <tr>
+    <td>Type</td>
+    <td><code>String</code></td>
+  </tr>
+  <tr>
+    <td>Nullable</td>
+    <td>No</td> 
+  </tr>
+</table>
+
+The directory where the `/libraries` folder resides.
+
 ### addon.self.browser
 <table>
   <tr>
@@ -55,6 +69,20 @@ The directory where the addon resides.
 </table>
 
 Returns either `chrome` or `firefox`, depending on the browser Scratch Addons is running at.
+
+### addon.self.disabled
+<table>
+  <tr>
+    <td>Type</td>
+    <td><code>Boolean</code></td>
+  </tr>
+  <tr>
+    <td>Nullable</td>
+    <td>No</td> 
+  </tr>
+</table>
+
+Whether the addon is currently disabled or not.
 
 ### addon.self.enabledLate
 <table>
@@ -72,6 +100,7 @@ Returns true if the addon was dynamically enabled. Otherwise, false.
 
 ## Events
 ### disabled
-Fires when the addon gets disabled and has the `dynamicDisable` manifest property
+Fires when the addon gets disabled and has the `dynamicDisable` manifest property.
+
 ### reenabled
 Fires when the addon gets reenabled after being disabled.

--- a/content/docs/reference/addon-api/addon.self.md
+++ b/content/docs/reference/addon-api/addon.self.md
@@ -10,6 +10,7 @@ weight: 1
 | Available in persistent scripts | ✔️ |
 | Required manifest permissions | None |
 
+## Description
 Allows addons to get information about themselves or the browser.
 
 ## Getters

--- a/content/docs/reference/addon-api/addon.self.md
+++ b/content/docs/reference/addon-api/addon.self.md
@@ -13,7 +13,7 @@ weight: 1
 ## Description
 Allows addons to get information about themselves or the browser.
 
-## Getters
+## Properties
 ### addon.self.id (string)
 The ID of the addon, in other words, the name of the folder.
 ### addon.self.dir (string)

--- a/content/docs/reference/addon-api/addon.self.md
+++ b/content/docs/reference/addon-api/addon.self.md
@@ -14,13 +14,60 @@ weight: 1
 Allows addons to get information about themselves or the browser.
 
 ## Properties
-### addon.self.id (string)
+### addon.self.id
+<table>
+  <tr>
+    <td>Type</td>
+    <td><code>String</code></td>
+  </tr>
+  <tr>
+    <td>Nullable</td>
+    <td>No</td> 
+  </tr>
+</table>
+
 The ID of the addon, in other words, the name of the folder.
-### addon.self.dir (string)
+
+### addon.self.dir
+<table>
+  <tr>
+    <td>Type</td>
+    <td><code>String</code></td>
+  </tr>
+  <tr>
+    <td>Nullable</td>
+    <td>No</td> 
+  </tr>
+</table>
+
 The directory where the addon resides.
-### addon.self.browser (string)
+
+### addon.self.browser
+<table>
+  <tr>
+    <td>Value</td>
+    <td><code>"chrome" | "firefox"</code></td>
+  </tr>
+  <tr>
+    <td>Nullable</td>
+    <td>No</td> 
+  </tr>
+</table>
+
 Returns either `chrome` or `firefox`, depending on the browser Scratch Addons is running at.
-### addon.self.enabledLate (boolean)
+
+### addon.self.enabledLate
+<table>
+  <tr>
+    <td>Type</td>
+    <td><code>Boolean</code></td>
+  </tr>
+  <tr>
+    <td>Nullable</td>
+    <td>No</td> 
+  </tr>
+</table>
+
 Returns true if the addon was dynamically enabled. Otherwise, false.
 
 ## Events

--- a/content/docs/reference/addon-api/addon.settings.md
+++ b/content/docs/reference/addon-api/addon.settings.md
@@ -12,7 +12,6 @@ weight: 2
 
 ## Description
 Allows addons to change their behavior according to user-specified addon settings.  
-This API is available even if an addon doesn't specify `settings` in its manifest, however all calls to `get()` will fail.
 
 ## Examples
 ### Reacting to settings change
@@ -52,9 +51,49 @@ addon.settings.addEventListener("change", function() {
   </tr>
 </table>
 
-Returns the user-specified value for that setting, or the default specified in the addon manifest if the user didn't specify a value by themselves.
-Throws if the specified setting ID wasn't declared inside `addon.json`.
+Returns the user-specified value for a provided setting ID.  
+The return value will depend on the setting type:
+
+<table>
+  <tr>
+    <th>Setting type</th>
+    <th>Return type</th>
+    <th>Example value</th>
+  </tr>
+  <tr>
+    <td><code>boolean</code></td>
+    <td><code>Boolean</code></td>
+    <th><code>true</code></th>
+  </tr>
+  <tr>
+    <td><code>positive_integer</code></td>
+    <td><code>Number</code></td>
+    <th><code>0</code></th>
+  </tr>
+  <tr>
+    <td><code>integer</code></td>
+    <td><code>Number</code></td>
+    <th><code>-2</code></th>
+  </tr>
+  <tr>
+    <td><code>string</code></td>
+    <td><code>String</code></td>
+    <th><code>"abc"</code></th>
+  </tr>
+  <tr>
+    <td><code>color</code></td>
+    <td><code>String</code></td>
+    <th><code>"#aabbcc"</code></th>
+  </tr>
+  <tr>
+    <td><code>select</code></td>
+    <td><code>String</code></td>
+    <th><code>"potentialValueId"</code></th>
+  </tr>
+</table>
+
+This method is guaranteed to return the valid type. `null` is never returned.
 
 ## Events
 ### change
-Fires when any of the addon's settings have changed. This is a good time to restart your addon, refresh the page, recalculate settings, etc.
+Fires when any of the addon's settings have changed.

--- a/content/docs/reference/addon-api/addon.settings.md
+++ b/content/docs/reference/addon-api/addon.settings.md
@@ -4,8 +4,11 @@ description: Allows addons to change their behavior according to user-specified 
 weight: 2
 ---
 
-**Available in persistent scripts.**  
-**Available in userscripts.**
+| | |
+|-|-|
+| Available in userscripts | ✔️ |
+| Available in persistent scripts | ✔️ |
+| Required manifest permissions | None |
 
 Allows addons to change their behavior according to user-specified addon settings.  
 This API is available even if an addon doesn't specify `settings` in its manifest, however all calls to `get()` will fail.

--- a/content/docs/reference/addon-api/addon.settings.md
+++ b/content/docs/reference/addon-api/addon.settings.md
@@ -14,6 +14,16 @@ weight: 2
 Allows addons to change their behavior according to user-specified addon settings.  
 This API is available even if an addon doesn't specify `settings` in its manifest, however all calls to `get()` will fail.
 
+## Examples
+### Reacting to settings change
+```js
+addon.settings.addEventListener("change", function() {
+  console.log("Settings changed!");
+  if(addon.settings.get("removeIdeasBtn") === true && tipsButtonShown === false) showTipsButton();
+  else if(addon.settings.get("removeIdeasBtn") === false && tipsButtonShown === true) hideTipsButton();
+});
+```
+
 ## Methods
 ### addon.settings.get
 <table>
@@ -52,11 +62,3 @@ Throws if the specified setting ID wasn't declared inside `addon.json`.
 ## Events
 ### change
 Fires when any of the addon's settings have changed. This is a good time to restart your addon, refresh the page, recalculate settings, etc.
-#### Example:
-```js
-addon.settings.addEventListener("change", function() {
-  console.log("Settings changed!");
-  if(addon.settings.get("removeIdeasBtn") === true && tipsButtonShown === false) showTipsButton();
-  else if(addon.settings.get("removeIdeasBtn") === false && tipsButtonShown === true) hideTipsButton();
-});
-```

--- a/content/docs/reference/addon-api/addon.settings.md
+++ b/content/docs/reference/addon-api/addon.settings.md
@@ -47,10 +47,6 @@ addon.settings.addEventListener("change", function() {
     <td><code>String | Number | Boolean</code></td>
   </tr>
   <tr>
-    <td>Nullable</td>
-    <td>No</td>
-  </tr>
-  <tr>
     <td>Throws if</td>
     <td>The given setting ID wasn't declared in the addon manifest.</td> 
   </tr>

--- a/content/docs/reference/addon-api/addon.settings.md
+++ b/content/docs/reference/addon-api/addon.settings.md
@@ -15,7 +15,37 @@ Allows addons to change their behavior according to user-specified addon setting
 This API is available even if an addon doesn't specify `settings` in its manifest, however all calls to `get()` will fail.
 
 ## Methods
-### addon.settings.get(optionIdString)
+### addon.settings.get
+<table>
+  <tr>
+    <th>Parameter</th>
+    <th>Type</th>
+    <th>Required</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>settingId</td>
+    <td><code>String</code></td>
+    <td>Yes</td>
+    <td>Setting ID to retrieve</td>
+  </tr>
+</table>
+
+<table>
+  <tr>
+    <td>Return value</td>
+    <td><code>String | Number | Boolean</code></td>
+  </tr>
+  <tr>
+    <td>Nullable</td>
+    <td>No</td>
+  </tr>
+  <tr>
+    <td>Throws if</td>
+    <td>The given setting ID wasn't declared in the addon manifest</td> 
+  </tr>
+</table>
+
 Returns the user-specified value for that setting, or the default specified in the addon manifest if the user didn't specify a value by themselves.
 Throws if the specified setting ID wasn't declared inside `addon.json`.
 

--- a/content/docs/reference/addon-api/addon.settings.md
+++ b/content/docs/reference/addon-api/addon.settings.md
@@ -10,6 +10,7 @@ weight: 2
 | Available in persistent scripts | ✔️ |
 | Required manifest permissions | None |
 
+## Description
 Allows addons to change their behavior according to user-specified addon settings.  
 This API is available even if an addon doesn't specify `settings` in its manifest, however all calls to `get()` will fail.
 

--- a/content/docs/reference/addon-api/addon.settings.md
+++ b/content/docs/reference/addon-api/addon.settings.md
@@ -14,7 +14,7 @@ weight: 2
 Allows addons to change their behavior according to user-specified addon settings.  
 This API is available even if an addon doesn't specify `settings` in its manifest, however all calls to `get()` will fail.
 
-## Functions
+## Methods
 ### addon.settings.get(optionIdString)
 Returns the user-specified value for that setting, or the default specified in the addon manifest if the user didn't specify a value by themselves.
 Throws if the specified setting ID wasn't declared inside `addon.json`.

--- a/content/docs/reference/addon-api/addon.settings.md
+++ b/content/docs/reference/addon-api/addon.settings.md
@@ -37,7 +37,7 @@ addon.settings.addEventListener("change", function() {
     <td>settingId</td>
     <td><code>String</code></td>
     <td>Yes</td>
-    <td>Setting ID to retrieve</td>
+    <td>Setting ID to retrieve.</td>
   </tr>
 </table>
 
@@ -52,7 +52,7 @@ addon.settings.addEventListener("change", function() {
   </tr>
   <tr>
     <td>Throws if</td>
-    <td>The given setting ID wasn't declared in the addon manifest</td> 
+    <td>The given setting ID wasn't declared in the addon manifest.</td> 
   </tr>
 </table>
 

--- a/content/docs/reference/addon-api/addon.tab/_index.md
+++ b/content/docs/reference/addon-api/addon.tab/_index.md
@@ -54,6 +54,7 @@ Returns either `"scratch-www"` (React based), `"scratchr2"` (jQuery based) or `n
     <td>Yes</td> 
   </tr>
 </table>
+
 If the tab is a project, it returns the viewing mode of the project: `"projectpage"`, `"editor"`, `"fullscreen"` or `"embed"`.  
 If not in a project, it will return `null`.
 
@@ -172,6 +173,115 @@ If the options object includes `{markAsSeen: true}`, the returned element will b
 
 Hides the given element with `display: none` when the addon is disabled. If the addon is enabled, it will set the display of the element to options.display which defaults as "".
 
+### addon.tab.copyImage
+<table>
+  <tr>
+    <td>Required manifest permissions</td>
+    <td><code>clipboardWrite</code></td>
+  </tr>
+</table>
+
+<table>
+  <tr>
+    <th>Parameter</th>
+    <th>Type</th>
+    <th>Required</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>dataURL</td>
+    <td><code>String</code></td>
+    <td>Yes</td>
+    <td>Data URL of a PNG image.</td>
+  </tr>
+</table>
+
+<table>
+  <tr>
+    <td>Return value</td>
+    <td><code>Promise&lt;void></code></td>
+  </tr>
+    <td>Promise rejects if</td>
+    <td>Image could not be copied.</td>
+</table>
+
+Copies a PNG image to the clipboard.  
+Only run this in response of the user explicitly pressing Ctrl+C.  
+Internally uses `browser.clipboard.setImageData` in Firefox and `navigator.clipboard.write` in Chrome.
+
+### addon.tab.scratchClass
+<table>
+  <tr>
+    <th>Parameter</th>
+    <th>Type</th>
+    <th>Required</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>unhashedClassName</td>
+    <td><code>String</code></td>
+    <td>Min 1</td>
+    <td>One or many unhashed Scratch stylesheet class names, as one argument each.</td>
+  </tr>
+  <tr>
+    <td>opts</td>
+    <td><code>Object</code></td>
+    <td>No</td>
+    <td>
+      <table>
+        <tr>
+          <th>Property</th>
+          <th>Type</th>
+          <th>Required</th>
+          <th>Description</th>
+        </tr>
+        <tr>
+          <td>others</td>
+          <td><code>String | String[]</code></td>
+          <td>Yes</td>
+          <td>Non-Scratch class(es) to merge</td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>
+
+<table>
+  <tr>
+    <td>Return value</td>
+    <td><code>String</code></td>
+  </tr>
+</table>
+
+Gets the hashed class name for a Scratch stylesheet class name.
+
+### addon.tab.scratchMessage
+<table>
+  <tr>
+    <th>Parameter</th>
+    <th>Type</th>
+    <th>Required</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>key</td>
+    <td><code>String</code></td>
+    <td>Yes</td>
+    <td>The Scratch translation key.</td>
+  </tr>
+</table>
+
+<table>
+  <tr>
+    <td>Return value</td>
+    <td><code>String | ""</code></td>
+  </tr>
+</table>
+
+Gets translation keys from the current Scratch tab.  
+If the message isn't found, `""` is returned and a warning is logged in the console.  
+Internally uses `window.django.gettext` or `window._messages`.  
+
 ## Events
 ### urlChange
 <table>
@@ -193,4 +303,4 @@ Hides the given element with `display: none` when the addon is disabled. If the 
 </table>
 
 Fires when Scratch dynamically changes the URL of the page. This usually happens when going inside/outside the editor, or into/outside full screen mode. This event does not trigger if the hash of the URL changes.  
-You can access `event.detail.oldUrl` and `event.detail.newUrl`
+You can access `event.detail.oldUrl` and `event.detail.newUrl`.

--- a/content/docs/reference/addon-api/addon.tab/_index.md
+++ b/content/docs/reference/addon-api/addon.tab/_index.md
@@ -166,6 +166,24 @@ Hides the given element with `display: none` when the addon is disabled. If the 
 
 ## Events
 ### urlChange
+<table>
+  <tr>
+    <th>Event detail property</th>
+    <th>Type</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>oldUrl</td>
+    <td><code>String</code></td>
+    <td>The URL before it was dynamically changed</td>
+  </tr>
+  <tr>
+    <td>newUrl</td>
+    <td><code>String</code></td>
+    <td>The new current URL value</td>
+  </tr>
+</table>
+
 Fires when Scratch dynamically changes the URL of the page. This usually happens when going inside/outside the editor, or into/outside full screen mode. This event does not trigger if the hash of the URL changes.  
 You can access `event.detail.oldUrl` and `event.detail.newUrl`
 #### Example:

--- a/content/docs/reference/addon-api/addon.tab/_index.md
+++ b/content/docs/reference/addon-api/addon.tab/_index.md
@@ -27,7 +27,7 @@ Returns either `"scratch-www"` (React based), `"scratchr2"` (jQuery based) or `n
 If the tab is a project, it returns the viewing mode of the project: `"projectpage"`, `"editor"`, `"fullscreen"` or `"embed"`.  
 If not in a project, it will return `null`.
 
-## Functions
+## Methods
 ### addon.tab.waitForElement(selector, optionalOptionsObject)
 **Since v1.4.0, this function does not react to attribute changes in the DOM. Please do not use this to react to attribute changes. You can still, however, match static attributes that stay the same since the element is created, until it is destroyed.**  
 Returns a promise that resolves to the found element when an element matching that selector is found.  

--- a/content/docs/reference/addon-api/addon.tab/_index.md
+++ b/content/docs/reference/addon-api/addon.tab/_index.md
@@ -19,7 +19,7 @@ Allows addons to get direct references to objects, which are particularly useful
 ### [addon.tab.redux](addon.tab.redux)
 TODO
 
-## Getters
+## Properties
 ### addon.tab.clientVersion
 Currently, the Scratch community website has 2 working clients used throughout the site, one React based and another jQuery based. This getter allows addons to change your behavior depending on the version of the current page.  
 Returns either `"scratch-www"` (React based), `"scratchr2"` (jQuery based) or `null`.

--- a/content/docs/reference/addon-api/addon.tab/_index.md
+++ b/content/docs/reference/addon-api/addon.tab/_index.md
@@ -4,8 +4,11 @@ description: Allows addon userscripts to get information about the tab they're c
 weight: 5
 ---
 
-**NOT available in persistent scripts.**  
-**Available in userscripts.**  
+| | |
+|-|-|
+| Available in userscripts | ✔️ |
+| Available in persistent scripts | ❌ |
+| Required manifest permissions | None |
 
 Allows addon userscripts to get information about the tab they're currently running on.
 

--- a/content/docs/reference/addon-api/addon.tab/_index.md
+++ b/content/docs/reference/addon-api/addon.tab/_index.md
@@ -10,6 +10,7 @@ weight: 5
 | Available in persistent scripts | ❌ |
 | Required manifest permissions | None |
 
+## Description
 Allows addon userscripts to get information about the tab they're currently running on.
 
 ## Sub-APIs

--- a/content/docs/reference/addon-api/addon.tab/_index.md
+++ b/content/docs/reference/addon-api/addon.tab/_index.md
@@ -21,9 +21,31 @@ TODO
 
 ## Properties
 ### addon.tab.clientVersion
+<table>
+  <tr>
+    <td>Value</td>
+    <td><code>"scratch-www" | "scratchr2"</code></td>
+  </tr>
+  <tr>
+    <td>Nullable</td>
+    <td>Yes</td> 
+  </tr>
+</table>
+
 Currently, the Scratch community website has 2 working clients used throughout the site, one React based and another jQuery based. This getter allows addons to change your behavior depending on the version of the current page.  
 Returns either `"scratch-www"` (React based), `"scratchr2"` (jQuery based) or `null`.
+
 ### addon.tab.editorMode
+<table>
+  <tr>
+    <td>Value</td>
+    <td><code>"projectpage" | "editor" | "fullscreen" | "embed"</code></td>
+  </tr>
+  <tr>
+    <td>Nullable</td>
+    <td>Yes</td> 
+  </tr>
+</table>
 If the tab is a project, it returns the viewing mode of the project: `"projectpage"`, `"editor"`, `"fullscreen"` or `"embed"`.  
 If not in a project, it will return `null`.
 

--- a/content/docs/reference/addon-api/addon.tab/_index.md
+++ b/content/docs/reference/addon-api/addon.tab/_index.md
@@ -50,13 +50,118 @@ If the tab is a project, it returns the viewing mode of the project: `"projectpa
 If not in a project, it will return `null`.
 
 ## Methods
-### addon.tab.waitForElement(selector, optionalOptionsObject)
+### addon.tab.waitForElement
+<table>
+  <tr>
+    <th>Parameter</th>
+    <th>Type</th>
+    <th>Required</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>selector</td>
+    <td><code>String</code></td>
+    <td>Yes</td>
+    <td>One or more selectors to match. Same parameter as <code>document.querySelector</code>.</td>
+  </tr>
+  <tr>
+    <td>options</td>
+    <td><code>Object</code></td>
+    <td>No</td>
+    <td>
+      <table>
+        <tr>
+          <th>Property</th>
+          <th>Type</th>
+          <th>Required</th>
+          <th>Default</th>
+          <th>Description</th>
+        </tr>
+        <tr>
+          <td>markAsSeen</td>
+          <td><code>Boolean</code></td>
+          <td>No</td>
+          <td><code>false</code></td>
+          <td>Whether it should mark resolved elements to be skipped next time or not.</td>
+        </tr>
+        <tr>
+          <td>condition</td>
+          <td><code>Function</code></td>
+          <td>No</td>
+          <td><code>() => true</code></td>
+          <td>A function that returns whether to resolve the selector or not. No arguments are passed.</td>
+        </tr>
+        <tr>
+          <td>reduxCondition</td>
+          <td><code>Function</code></td>
+          <td>No</td>
+          <td><code>() => true</code></td>
+          <td>A function that returns whether to resolve the selector or not. <code>addon.tab.redux</code> is passed as an argument.</td>
+        </tr>
+        <tr>
+          <td>reduxEvents</td>
+          <td><code>String[]</code></td>
+          <td>No</td>
+          <td><code>[]</code></td>
+          <td>An array of Redux events that must be dispatched before resolving the selector.</td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>
+
+<table>
+  <tr>
+    <td>Return value</td>
+    <td><code>Promise&lt;HTMLElement></code></td>
+  </tr>
+</table>
+
 **Since v1.4.0, this function does not react to attribute changes in the DOM. Please do not use this to react to attribute changes. You can still, however, match static attributes that stay the same since the element is created, until it is destroyed.**  
 Returns a promise that resolves to the found element when an element matching that selector is found.  
 If the element already exists, it automatically resolves.  
 Takes the same argument as `document.querySelectorAll`.  
 If the options object includes `{markAsSeen: true}`, the returned element will be marked as seen by the addon, and will be ignored for any future calls to `waitForElement()`, no matter the selector or options object given to it. This is useful for cases where you only want to do an operation once per element.
-### addon.tab.displayNoneWhileDisabled(el, optionalOptionsObject)
+
+### addon.tab.displayNoneWhileDisabled
+<table>
+  <tr>
+    <th>Parameter</th>
+    <th>Type</th>
+    <th>Required</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>element</td>
+    <td><code>HTMLElement</code></td>
+    <td>Yes</td>
+    <td>Element to hide</td>
+  </tr>
+  <tr>
+    <td>options</td>
+    <td><code>Object</code></td>
+    <td>No</td>
+    <td>
+      <table>
+        <tr>
+          <th>Property</th>
+          <th>Type</th>
+          <th>Required</th>
+          <th>Default</th>
+          <th>Description</th>
+        </tr>
+        <tr>
+          <td>display</td>
+          <td><code>String</code></td>
+          <td>No</td>
+          <td><code>""</code></td>
+          <td>The <code>display</code> CSS value to use when the addon is enabled.</td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>
+
 Hides the given element with `display: none` when the addon is disabled. If the addon is enabled, it will set the display of the element to options.display which defaults as "".
 
 ## Events

--- a/content/docs/reference/addon-api/addon.tab/_index.md
+++ b/content/docs/reference/addon-api/addon.tab/_index.md
@@ -13,6 +13,14 @@ weight: 5
 ## Description
 Allows addon userscripts to get information about the tab they're currently running on.
 
+## Examples
+### Reacting to URL dynamically changed
+```js
+addon.tab.addEventListener("urlChange", function(event) {
+  console.log(`URL changed! It was previously ${event.detail.oldUrl}, it's now ${event.detail.newUrl}`);
+});
+```
+
 ## Sub-APIs
 ### [addon.tab.traps](addon.tab.traps)
 Allows addons to get direct references to objects, which are particularly useful for enhancing the editor, like the Scratch VM or the Blockly instance.
@@ -186,9 +194,3 @@ Hides the given element with `display: none` when the addon is disabled. If the 
 
 Fires when Scratch dynamically changes the URL of the page. This usually happens when going inside/outside the editor, or into/outside full screen mode. This event does not trigger if the hash of the URL changes.  
 You can access `event.detail.oldUrl` and `event.detail.newUrl`
-#### Example:
-```js
-addon.tab.addEventListener("urlChange", function(event) {
-  console.log(`URL changed! It was previously ${event.detail.oldUrl}, it's now ${event.detail.newUrl}`);
-});
-```


### PR DESCRIPTION
- Fix wrong titles
- Add tables for availability in persistent scripts, userscripts, and required permissons
- Rename "getters" to "properties" and "functions" to "methods"
- Add tables that show the possible types/values of properties, function parameters, function return values and event detail properties
- Add missing properties and methods.
- Rewrite some property/method descriptions, trying to be more consistent with the JSDoc. I plan to have the first lines of the descriptions in the docs be the JSDoc descriptions. And if possible, link JSDoc to the correct place in the docs.
- Write some examples