### PR TITLE
Do a general policies section, add Security Policy

### DIFF
--- a/content/docs/policies/_index.md
+++ b/content/docs/policies/_index.md
@@ -1,0 +1,9 @@
+---
+title: Policies
+description: All of our policies, statements, information, and procedures related to Scratch Addons.
+weight: 99
+aliases:
+  - /docs/privacy
+---
+
+All of our policies, statements, information, and procedures related to Scratch Addons.

--- a/content/docs/policies/chrome-web-store-privacy-information.md
+++ b/content/docs/policies/chrome-web-store-privacy-information.md
@@ -4,6 +4,7 @@ description: This is how we fill the "privacy practices" form on the Chrome Web 
 weight: 100
 aliases:
   - /docs/chrome-web-store-privacy-information
+  - /docs/policies/chrome-web-store-privacy-information
 ---
 
 This is how we fill the "privacy practices" form on the Chrome Web Store Developer Dashboard.

--- a/content/docs/policies/privacy/_index.md
+++ b/content/docs/policies/privacy/_index.md
@@ -1,0 +1,10 @@
+---
+title: Privacy Policy
+description: Our policy regarding the collection, use, and disclosure of personal data when using the Scratch Addons extension and website.
+weight: 1
+aliases:
+  - /docs/privacy/policies
+  - /privacy
+---
+
+Our policy regarding the collection, use, and disclosure of personal data when using the Scratch Addons extension and website.

--- a/content/docs/policies/privacy/extension.md
+++ b/content/docs/policies/privacy/extension.md
@@ -3,7 +3,8 @@ title: Extension Privacy Policy
 toc_title: Extension
 description: This page informs you of our policies regarding the collection, use, and disclosure of personal data when using the Scratch Addons extension and the choices you have associated with that data.
 aliases:
-  - /privacy
+  - /docs/privacy/policies/extension
+  - /privacy/extension
 ---
 
 > Last updated: 28 May 2021

--- a/content/docs/policies/privacy/website.md
+++ b/content/docs/policies/privacy/website.md
@@ -2,6 +2,9 @@
 title: Website Privacy Policy
 toc_title: Website
 description: This page informs you of our policies regarding the collection, use, and disclosure of personal data when using the Scratch Addons website and the choices you have associated with that data.
+aliases:
+  - /docs/privacy/policies/extension
+  - /privacy/website
 ---
 
 > Last updated: 28 May 2021

--- a/content/docs/policies/security.md
+++ b/content/docs/policies/security.md
@@ -1,0 +1,18 @@
+---
+title: Security Policy
+weight: 2
+---
+
+## Supported Versions
+
+Scratch Addons should not have any security issues in its most recent version, found in the Chrome Web Store and Addons for Firefox.
+
+We only officially support the most recent stable versions of Chrome and Firefox. However, if you found a vulnerability that only occurs if using an old browser version, please report it (see below).
+
+## Reporting a Vulnerability
+
+If you find a vulnerability within Scratch Addons (any repository belonging to the organization) please contact World_Languages privately by emailing worldxlanguages (at) gmail.com. If you don't get a response within 48 hours, please create an issue in this repository mentioning you sent an email.
+
+## Vulnerabilities Disclosed
+
+See our advisories that we have published for vulnerabilities that we have disclosed on [this page](https://github.com/ScratchAddons/ScratchAddons/security/advisories?state=published).

--- a/content/docs/privacy/_index.md
+++ b/content/docs/privacy/_index.md
@@ -1,7 +1,0 @@
----
-title: Privacy
-description: All things related to how Scratch Addons handles your data.
-weight: 99
----
-
-All things related to how Scratch Addons handles your data.

--- a/content/docs/privacy/policies/_index.md
+++ b/content/docs/privacy/policies/_index.md
@@ -1,7 +1,0 @@
----
-title: Privacy Policies
-description: Our policies regarding the collection, use, and disclosure of personal data when using the Scratch Addons extension and website.
-weight: 1
----
-
-Our policies regarding the collection, use, and disclosure of personal data when using the Scratch Addons extension and website.


### PR DESCRIPTION
The `policies` directory have been made from the former `privacy` directory. It contains the same folder along with the newly-added, but already existing Security Policy. The term "policies" is quite lax to cover lots of types of statements, policies, etc. (see [GitHub's site policy](https://docs.github.com/en/github/site-policy) for example)

The redirect `/privacy` has been redirected to `/docs/policies/privacy` instead of `/docs/policies/privacy/extension` to avoid confusion. As a replacement, `/privacy/extension` now redirects to `/docs/policies/privacy/extension` and `/privacy/website` now redirects to `/docs/policies/privacy/website`.