### PR TITLE
Update addon.* API and manifest docs

### DIFF
--- a/content/docs/develop/addon-types/persistent-scripts.md
+++ b/content/docs/develop/addon-types/persistent-scripts.md
@@ -4,6 +4,9 @@ description: Persistent scripts allow you to run JavaScript in the background! T
 aliases: 
   - /docs/developing/about-persistent-scripts
 ---
+
+> **It's recommended to avoid persistent scripts when possible. A future migration to [Manifest V3](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/#background-service-workers) will require us to use service workers instead of background pages, making persistent scripts a challenge. The fewer persistent scripts there are when we migrate, the better.**
+
 ## What are they?
 Persistent scripts allow you to run JavaScript in the background! They're awesome to notify the user about stuff, or preload data so it's ready when the user needs it.
 

--- a/content/docs/reference/addon-api/addon.auth.md
+++ b/content/docs/reference/addon-api/addon.auth.md
@@ -18,8 +18,8 @@ Allows addons to get information about the current Scratch account session.
 ## Examples
 ### Reacting to auth info change
 ```js
-addon.auth.addEventListener("change", function() {
-  console.log(addon.auth.isLoggedIn);
+addon.auth.addEventListener("change", async function() {
+  console.log(await addon.auth.fetchIsLoggedIn());
 });
 ```
 
@@ -40,65 +40,6 @@ Language of the Scratch website.
 This language option can be changed by the user in the footer of Scratch's website.  
 This property changing does not fire a `change` event.
 
-### `addon.auth.isLoggedIn`
-<table>
-  <tr>
-    <td>Type</td>
-    <td><code>Boolean</code></td>
-  </tr>
-  <tr>
-    <td>Nullable</td>
-    <td>No</td> 
-  </tr>
-</table>
-
-Whether the user is logged in or not.
-
-### `addon.auth.username`
-<table>
-  <tr>
-    <td>Type</td>
-    <td><code>String</code></td>
-  </tr>
-  <tr>
-    <td>Nullable</td>
-    <td>Yes</td> 
-  </tr>
-</table>
-
-Username of the currently logged in user.  
-Will be `null` if `addon.auth.isLoggedIn` is `false`.
-
-### `addon.auth.userId`
-<table>
-  <tr>
-    <td>Type</td>
-    <td><code>Number</code></td>
-  </tr>
-  <tr>
-    <td>Nullable</td>
-    <td>Yes</td> 
-  </tr>
-</table>
-
-User ID of the currently logged in user.  
-Will be `null` if `addon.auth.isLoggedIn` is `false`.
-
-### `addon.auth.xToken`
-<table>
-  <tr>
-    <td>Type</td>
-    <td><code>String</code></td>
-  </tr>
-  <tr>
-    <td>Nullable</td>
-    <td>Yes</td> 
-  </tr>
-</table>
-
-Value of the `X-Token` header used in the Scratch REST API.  
-Will be `null` if `addon.auth.isLoggedIn` is `false`.
-
 ### `addon.auth.csrfToken`
 <table>
   <tr>
@@ -112,8 +53,51 @@ Will be `null` if `addon.auth.isLoggedIn` is `false`.
 </table>
 
 Value of the `scratchcsrftoken` cookie.  
-Will be `null` if `addon.auth.isLoggedIn` is `false`.
+
+## Methods
+### `addon.auth.fetchIsLoggedIn`
+<table>
+  <tr>
+    <td>Return value</td>
+    <td><code>Promise&lt;Boolean></code></td>
+  </tr>
+</table>
+
+Fetches whether the user is logged in or not.
+
+### `addon.auth.fetchUsername`
+<table>
+  <tr>
+    <td>Return value</td>
+    <td><code>Promise&lt;String | null></code></td>
+  </tr>
+</table>
+
+Fetches the username of the currently logged in user.  
+Will resolve to `null` if `addon.auth.fetchIsLoggedIn()` returns `Promise<false>`.
+
+### `addon.auth.fetchUserId`
+<table>
+  <tr>
+    <td>Return value</td>
+    <td><code>Promise&lt;Number | null></code></td>
+  </tr>
+</table>
+
+Fetches the user ID of the currently logged in user.  
+Will resolve to `null` if `addon.auth.fetchIsLoggedIn()` returns `Promise<false>`.
+
+### `addon.auth.fetchXToken`
+<table>
+  <tr>
+    <td>Return value</td>
+    <td><code>Promise&lt;String | null></code></td>
+  </tr>
+</table>
+
+Fetches the value of the `X-Token` header used in the Scratch REST API.  
+Will resolve to `null` if `addon.auth.fetchIsLoggedIn()` returns `Promise<false>`.
 
 ## Events
 ### `change`
-Fires when any of `isLoggedIn`, `username`, `userId`, `xToken` or `csrfToken` change.
+Fires when the CSRF token, username, user ID or X-Token change.

--- a/content/docs/reference/addon-api/addon.tab/addon.tab.appendToSharedSpace.md
+++ b/content/docs/reference/addon-api/addon.tab/addon.tab.appendToSharedSpace.md
@@ -395,9 +395,7 @@ Addition of the `|` separator is handled by the space.
 </table>
 
 ### `beforeRemixButton`
-Links placed after the "report" button in a specific post.  
-If the "report" button does not exist, a visible placeholder dot will be added to the page automatically to act as a separator between the `forumsBeforePostReport` and `forumsAfterPostReport` spaces.  
-Addition of the `|` separator is handled by the space.
+Elements that go to the left of the "remix" or "see inside" buttons in project pages.
 
 <table>
   <tr>
@@ -428,5 +426,10 @@ Addition of the `|` separator is handled by the space.
     <td><code>project-info</code></td>
     <td>Sprite and script count</td>
     <td>0</td>
+  </tr>
+  <tr>
+    <td><code>turbowarp-player</code></td>
+    <td>TurboWarp button</td>
+    <td>1</td>
   </tr>
 </table>

--- a/content/docs/reference/addon-api/addon.tab/addon.tab.appendToSharedSpace.md
+++ b/content/docs/reference/addon-api/addon.tab/addon.tab.appendToSharedSpace.md
@@ -310,6 +310,47 @@ Buttons that go after the "copy link" button in project pages.
   </tr>
 </table>
 
+### `beforeRemixButton`
+Elements that go to the left of the "remix" or "see inside" buttons in project pages.
+
+<table>
+  <tr>
+    <td>Space parent element</td>
+    <td><code>div.project-buttons</code></td>
+  </tr>
+  <tr>
+    <td>Space starting bound</td>
+    <td>None</td>
+  </tr>
+  <tr>
+    <td>Space ending bound</td>
+    <td>Remix button or see inside button</td>
+  </tr>
+  <tr>
+    <td><code>scope</code> option used</td>
+    <td>❌</td>
+  </tr>
+</table>
+
+<table>
+  <tr>
+    <th>Addon ID</th>
+    <th>Element</th>
+    <th>Order number</th>
+  </tr>
+  <tr>
+    <td><code>project-info</code></td>
+    <td>Sprite and script count</td>
+    <td>0</td>
+  </tr>
+  <tr>
+    <td><code>turbowarp-player</code></td>
+    <td>TurboWarp button</td>
+    <td>1</td>
+  </tr>
+</table>
+
+## Scratch forums spaces
 ### `forumsBeforePostReport`
 Links placed before the "report" button in a specific post.  
 If the "report" button does not exist, a visible placeholder dot will be added to the page automatically to act as a separator between the `forumsBeforePostReport` and `forumsAfterPostReport` spaces.  
@@ -391,45 +432,5 @@ Addition of the `|` separator is handled by the space.
     <td><code>show-bbcode</code></td>
     <td>Show BBCode button</td>
     <td>0</td>
-  </tr>
-</table>
-
-### `beforeRemixButton`
-Elements that go to the left of the "remix" or "see inside" buttons in project pages.
-
-<table>
-  <tr>
-    <td>Space parent element</td>
-    <td><code>div.project-buttons</code></td>
-  </tr>
-  <tr>
-    <td>Space starting bound</td>
-    <td>None</td>
-  </tr>
-  <tr>
-    <td>Space ending bound</td>
-    <td>Remix button or see inside button</td>
-  </tr>
-  <tr>
-    <td><code>scope</code> option used</td>
-    <td>❌</td>
-  </tr>
-</table>
-
-<table>
-  <tr>
-    <th>Addon ID</th>
-    <th>Element</th>
-    <th>Order number</th>
-  </tr>
-  <tr>
-    <td><code>project-info</code></td>
-    <td>Sprite and script count</td>
-    <td>0</td>
-  </tr>
-  <tr>
-    <td><code>turbowarp-player</code></td>
-    <td>TurboWarp button</td>
-    <td>1</td>
   </tr>
 </table>

--- a/content/docs/reference/addon-manifest.md
+++ b/content/docs/reference/addon-manifest.md
@@ -21,7 +21,7 @@ The description of the addons. Must end with a dot.
    
 Use standard grammar for referring to parts of the Scratch website or editor:  
 
-**Pages on the website**
+**Pages on the website:**
 * project page
 * editor
 * (user) profile
@@ -31,7 +31,7 @@ Use standard grammar for referring to parts of the Scratch website or editor:
 * (forum) post
 * (Scratch) 2.0/3.0-styled page *(a page which looks like Scratch 2.0/3.0, is a part of scratchr2/scratch-www)*
 
-**Scratch UI elements**
+**Scratch UI elements:**
 * (website) navigation bar *(only use when talking about the website)*
 * (editor) menu bar *(only use when talking about the editor)*
 * sprite pane *(the list of sprites below the stage)*

--- a/content/docs/reference/addon-manifest.md
+++ b/content/docs/reference/addon-manifest.md
@@ -12,12 +12,52 @@ Addons are located inside the `addons` folder. Each addon is inside its own fold
 In order to tell the addon loader how the addon plans to work, addons use a standard `addon.json` file located at the root of the addon's folder.  
 
 ## `name` (string, required)
-The name of the addon. Don't make it too long.  
-Try to make a descriptive name, avoid words like "Scratch", "tool", "feature".
+The name of the addon. Must be `Sentence case`.  
+It needs to be relatively short and consistent with other addon's names.  
+Use nouns instead of verbs (for example, `Customizable new sprite position` instead of `Change new sprite position`).
 
 ## `description` (string, required)
-The description of the addons.
-For consistency, descriptions **must** end with a dot.
+The description of the addons. Must end with a dot.  
+   
+Use standard grammar for referring to parts of the Scratch website or editor:  
+
+**Pages on the website**
+* project page
+* editor
+* (user) profile
+* studio page
+* forums
+* (forum) topic
+* (forum) post
+* (Scratch) 2.0/3.0-styled page *(a page which looks like Scratch 2.0/3.0, is a part of scratchr2/scratch-www)*
+
+**Scratch UI elements**
+* (website) navigation bar *(only use when talking about the website)*
+* (editor) menu bar *(only use when talking about the editor)*
+* sprite pane *(the list of sprites below the stage)*
+* costume editor *(not paint editor)*, list of costumes
+* list of sounds, costume/sound list *(for features that work with both costumes and sounds)*
+* costume/sound *(not asset)*
+* block category
+* block category menu
+* block palette
+* code area *(not workspace - Code tab excluding the block palette)*
+* block dropdown *(a dropdown menu opened by clicking a block input)*
+* block context menu *(a menu opened by right clicking a block)*
+* script *(not stack of blocks)*
+* extension
+* comment (on the website/in the code area)
+
+**Locations of added UI elements:**
+* in *(not on)* the navigation bar
+* on *(not in)* the forums
+* on *(not in)* the stage
+* above the stage (in the editor/on the project page)
+* next to the green flag
+* next to the Remix button
+
+**Common words:**
+* customizable
 
 ## `tags` (array, required)
 Tags are used for filtering and badges on the Scratch Addons settings page.  

--- a/content/docs/reference/addon-manifest.md
+++ b/content/docs/reference/addon-manifest.md
@@ -61,8 +61,125 @@ Use standard grammar for referring to parts of the Scratch website or editor:
 
 ## `tags` (array, required)
 Tags are used for filtering and badges on the Scratch Addons settings page.  
-One of these is **required**:  `community`, `editor`, `popup`, `easterEgg`.  
-Other options are: `theme`, `beta`, `recommended`, `forums`, `danger`, `codeEditor`, `costumeEditor`, `projectPlayer`, `editorMenuBar` `projectPage`, `profiles`, `studios`, `comments`.
+
+### Required factual tags
+Addons must have one of these tags. No less than one, no more than one.
+
+<table>
+  <tr>
+    <th>Tag name</th>
+    <th>Used by settings page</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td><code>community</code></td>
+    <td>✔️</td>
+    <td>Scratch website features</td>
+  </tr>
+  <tr>
+    <td><code>editor</code></td>
+    <td>✔️</td>
+    <td>Scratch editor features</td>
+  </tr>
+  <tr>
+    <td><code>popup</code></td>
+    <td>✔️</td>
+    <td>Extension popup features</td>
+  </tr>
+</table>
+
+## Optional factual tags
+Addon authors can usually determine these tags themselves.
+
+<table>
+  <tr>
+    <th>Tag name</th>
+    <th>Used by settings page</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td><code>theme</code></td>
+    <td>✔️</td>
+    <td>Addons that should be listed in the "themes" category. Tags <code>community</code> or <code>editor</code> are still required.</td>
+  </tr>
+  <tr>
+    <td><code>easterEgg</code></td>
+    <td>✔️</td>
+    <td>Addons with this tag are visible in the settings page while disabled only after typing the Konami code.</td>
+  </tr>
+  <tr>
+    <td><code>codeEditor</code></td>
+    <td>✔️</td>
+    <td>Addons that mainly affect the Code tab of the editor.</td>
+  </tr>
+  <tr>
+    <td><code>costumeEditor</code></td>
+    <td>✔️</td>
+    <td>Addons that mainly affect the Backdrops/Costumes tab of the editor.</td>
+  </tr>
+  <tr>
+    <td><code>projectPlayer</code></td>
+    <td>✔️</td>
+    <td>Addons that affect the project player in both the website and editor, or that add UI elements above the stage.</td>
+  </tr>
+  <tr>
+    <td><code>editorMenuBar</code></td>
+    <td>❌</td>
+    <td>Addons that add UI elements to the editor's menu bar.</td>
+  </tr>
+  <tr>
+    <td><code>projectPage</code></td>
+    <td>✔️</td>
+    <td>Addons that affect project pages on the website.</td>
+  </tr>
+  <tr>
+    <td><code>profiles</code></td>
+    <td>✔️</td>
+    <td>Addons that affect profile pages on the website.</td>
+  </tr>
+  <tr>
+    <td><code>forums</code></td>
+    <td>✔️</td>
+    <td>Addons that affect the Scratch Forums.</td>
+  </tr>
+  <tr>
+    <td><code>studios</code></td>
+    <td>❌</td>
+    <td>Addons that affect studio pages on the website.</td>
+  </tr>
+  <tr>
+    <td><code>comments</code></td>
+    <td>❌</td>
+    <td>Addons that affect comments on the website, inside project pages, profiles and studios.</td>
+  </tr>
+</table>
+
+### Optional subjective tags
+Addon authors shouldn't add these tags themselves.  
+Whether to add any of these tags will be discussed before merging the addon to the repository.
+
+<table>
+  <tr>
+    <th>Tag name</th>
+    <th>Used by settings page</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td><code>recommended</code></td>
+    <td>✔️</td>
+    <td>Addons that add highly requested, removed, or obvious missing features.</td>
+  </tr>
+  <tr>
+    <td><code>beta</code></td>
+    <td>✔️</td>
+    <td>Addons that haven't been deeply tested, may break in the future or are known to not work properly.</td>
+  </tr>
+  <tr>
+    <td><code>danger</code></td>
+    <td>✔️</td>
+    <td>Addons that users shouldn't enable without paying close attention.</td>
+  </tr>
+</table>
 
 ## `permissions` (array)
 You can specify permissions by providing a `permissions` array.  


### PR DESCRIPTION
Related to #75

- Update addon.auth to current prerelease async implementation
- Update beforeRemixButton sharedSpace info
- Add a note on addon types > persistent scripts, discouraging the creation of addons that rely on them
- Add a list of common terms to manifest docs > description
- Add more info on addon tags, split into 3 tables