### PR TITLE
Fix incorrect referral to userscripts

### DIFF
--- a/content/docs/develop/addon-types/userstyles.md
+++ b/content/docs/develop/addon-types/userstyles.md
@@ -34,7 +34,7 @@ Example manifest:
 }
 ```
 
-## Debugging userscripts
+## Debugging userstyles
 **Make sure to refresh Scratch Addons from `chrome://extensions` after doing any changes to your addon.**  
 If you don't see your userstyle working, make sure your addon is enabled.  
 If you're still having trouble, please create an issue in this repo.


### PR DESCRIPTION
The documentation [subheader](https://scratchaddons.com/docs/develop/addon-types/userstyles/#debugging-userscripts) (in _Docs Home -> Developing -> Addon Types -> Userstyles_) incorrectly says "Debugging userscripts" instead of "Debugging userstyles". This PR fixes that.