### PR TITLE
Fixed a link

### DIFF
--- a/content/docs/develop/getting-started/creating-an-addon.md
+++ b/content/docs/develop/getting-started/creating-an-addon.md
@@ -7,7 +7,7 @@ aliases:
 Required software: text editor, Chrome.  
 If possible, disable the Scratch Addons extension you downloaded from the store before proceeding to avoid issues.
 
-## Step 1: Read about [addon basics](addon-basics)
+## Step 1: Read about [addon basics](/docs/develop/getting-started/addon-basics/)
 Make sure to read that article to be familiar with the terminology.
 
 ## Step 2: Fork/clone the repo


### PR DESCRIPTION
https://scratchaddons.com/docs/develop/getting-started/creating-an-addon/#step-1-read-about-addon-basicsaddon-basics has a bad link that goes to https://scratchaddons.com/docs/develop/getting-started/creating-an-addon/addon-basics which doesn't work. This patch changes it to https://scratchaddons.com/docs/develop/getting-started/addon-basics/
<img width="960" alt="image" src="https://user-images.githubusercontent.com/57809064/146982630-6072d8a8-b7a7-4a72-9420-7096dff979da.png">
