### PR TITLE
Fix typo of "All-in-one"

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -67,7 +67,7 @@ PlayerModal:
 # Strings used for / (index)
 IndexPage:
   Intro:
-    Tagline: All in one browser extension for Scratch
+    Tagline: All-in-one browser extension for Scratch
     Description: Scratch Addons is a browser extension that provides new features and themes for the Scratch website and project editor. It has a mission to collect, archive, and put into use userstyles and userscripts, developed by several members of the Scratch community.
     InstallButton:
       Loading: Loading...


### PR DESCRIPTION
We have it dashed on the repository and the organization, so this should be also.