### PR TITLE
Add quality guidelines and addon compatibility checklist

### DIFF
--- a/content/docs/develop/getting-started/creating-an-addon.md
+++ b/content/docs/develop/getting-started/creating-an-addon.md
@@ -78,5 +78,6 @@ Make sure your addon doesn't break other addons.
 Make sure your code is understandable; having unnecessary comments is better than no comments.
 
 ## Step 12: Send a pull request!
-Fork the repo if you haven't already, commit your new addon and send a PR!  
-Keep in mind we might request you to make some changes, however, we will probably accept your addon as long as it's minimally suitable.
+Fork the repo if you haven't already, create a new branch, commit your new addon, and send a PR!  
+Keep in mind we might request that you make some changes. However, we will probably accept your addon as long as it's minimally suitable.  
+To keep the process smooth and improve the chances of your PR being merged, you should review the [quality guidelines](/docs/develop/getting-started/quality-guidelines) that we abide by.

--- a/content/docs/develop/getting-started/quality-guidelines.md
+++ b/content/docs/develop/getting-started/quality-guidelines.md
@@ -1,0 +1,18 @@
+---
+title: Quality Guidelines
+aliases:
+  - /docs/developing/getting-started/quality-guidelines
+---
+Keep these guidelines in mind when creating or reviewing a pull request (PR). If you're not sure about a certain guideline when creating a PR, you can submit the PR as a draft and mention that you need help with a specific aspect of your PR. Many developers and community members are willing and able to help your PR improve!
+
+All PRs:
+- should have sound reasoning as to why they should be merged. This should be specified under the "Reason for changes" header when writing the PR description. Even if it seems obvious, others may need the additional context. PRs with little to no reason to be merged are likely to be delayed, ignored, or even closed.
+- must support both the Chromium and Firefox browser engines. Avoid using new or experimental web technologies unless a fallback is implemented that preserves feature parity. View the [unsupported browser](https://scratchaddons.com/unsupported-browser/) page to determine the current minimum versions that must be supported.
+- must be tested thoroughly. We have a very large userbase, so it's especially important that all possible use cases are considered. Every PR should be tested on a Chromium-based browser (Chrome, Edge, Brave, or another) **and** Firefox. Any tests done should be added to the "Tests" section of the PR description.
+- must have **all** code reviewed line-by-line. **Org members, this is required in order to give approval.**
+- should be reviewed by someone familiar with the aspects that the PR is changing. This isn't a hard requirement, but a person like this will help iron out edge cases and minor issues.
+
+New addons:
+- must have clear, concise, and easy-to-understand titles, descriptions, info notices (if any), and setting names (if any). English is required: the base addon manifest is used as a reference for our translators. The developers and members of the community should scrutinize and help with this. An effective meter for this is to test it **blindly** -- that is, download and try out the addon before reading the PR description.
+- must be easy to use. The labels and design language used in any UI that the addon adds or modifies should be understandable by whoever will be using that addon. Again, testing blindly is an effective meter for this. Addons without an effective UI communicating its changes will be ranked lower than other addons in the settings page.
+- must be compatible with our existing addons. This doesn't just mean avoiding bugs: addons should complement each other by supporting each other's features. For example, an addon that has a user interface should support our respective dark mode addon. View the [compatibility checklist](/docs/reference/compatibility-checklist) for common issues to consider.


### PR DESCRIPTION
This PR adds quality guidelines for PRs to [the main extension repo](https://github.com/ScratchAddons/ScratchAddons/).

Although it doesn't exist just yet, an addon compatibility checklist will also be added as a complementing page. This will specify which addons need to be considered for each aspect of the website being modified.