### PR TITLE
Use JSDoc-esque tables for addon manifest

### DIFF
--- a/content/docs/reference/addon-manifest.md
+++ b/content/docs/reference/addon-manifest.md
@@ -8,12 +8,24 @@ aliases:
 Addons are located inside the `addons` folder. Each addon is inside its own folder as well.
 In order to tell the addon loader how the addon plans to work, addons use a standard `addon.json` file located at the root of the addon's folder.  
 
-## `name` (string, required)
+## `name`
+
+| | |
+| - | - |
+| Type | `String` |
+| Required | ✔️ |
+
 The name of the addon. Must be `Sentence case`.  
 It needs to be relatively short and consistent with other addon's names.  
 Use nouns instead of verbs (for example, `Customizable new sprite position` instead of `Change new sprite position`) unless doing so would result in the addon name being overly complicated.
 
-## `description` (string, required)
+## `description`
+
+| | |
+| - | - |
+| Type | `String` |
+| Required | ✔️ |
+
 The description of the addons. Must end with a period.  
    
 Use standard grammar for referring to parts of the Scratch website or editor:  
@@ -60,7 +72,13 @@ Use standard grammar for referring to parts of the Scratch website or editor:
 * better
 * with ... key
 
-## `tags` (array, required)
+## `tags`
+
+| | |
+| - | - |
+| Type | `Array` |
+| Required | ✔️ |
+
 Tags are used for filtering and badges on the Scratch Addons settings page.  
 
 ### Required factual tags
@@ -187,19 +205,40 @@ Whether to add any of these tags will be discussed before merging the addon to t
   </tr>
 </table>
 
-## `versionAdded` (string, required)
+## `versionAdded`
+
+| | |
+| - | - |
+| Type | `String` |
+| Required | ✔️ |
+
 The version the addon was added. If the value is the same as the current version of the extension, the addon will get the new tag.
 
-## `permissions` (array)
+## `permissions`
+
+| | |
+| - | - |
+| Type | `Array` |
+
 You can specify permissions by providing a `permissions` array.  
 Possible items: `notifications`, `clipboardWrite`.  
 
-## `userscripts` and `userstyles` (array)
+## `userscripts` and `userstyles`
+
+| | |
+| - | - |
+| Type | `Array` |
+
 Declaring userscripts and userstyles is very similar.
 This is an array of objects, not strings.  
 Each object must specify the url to the userscript/userstyle through the `url` property, and provide an array of URL matches. If any of these patterns match, the userscript/userstyle is injected.
 
-### `matches` (array)
+### `matches`
+
+| | |
+| - | - |
+| Type | `Array` |
+
 Matches that allow the userscript/userstyle to run on. Values can be a URL match pattern, or `projects`, `projectEmbeds`, `studios`, `profiles`, `topics`, `newPostScreens`, `editingScreens`, `forums`, `scratchWWWNoProject`.
 ```json
 {
@@ -216,11 +255,25 @@ Matches that allow the userscript/userstyle to run on. Values can be a URL match
 }
 ```
 
-### `runAtComplete` (boolean, userscripts only)
+### `runAtComplete`
+
+| | |
+| - | - |
+| Type | `Boolean` |
+| Available in userscripts | ✔️ |
+| Available in userstyles | ❌ |
+
 Specifies whether the userscript should run after the page has loaded (after the window load event). If unspecified, `true` is assumed.  
 If set to `false`, the userscript is only guaranteed to run after the \<head> element of the document has loaded.
 
-### `if` (object, userstyles only)
+### `if`
+
+| | |
+| - | - |
+| Type | `Object` |
+| Available in userscripts | ❌ |
+| Available in userstyles | ✔️ |
+
 Optionally, you can provide an `if` object that will only apply your userstyle if any of the specified sub-properties evaluates to `true`. More advanced behavior can be achieved in userscripts using [`addon.settings.get`](https://scratchaddons.com/docs/reference/addon-api/addon.settings/#addonsettingsget) and [`addon.self.getEnabledAddons`](https://scratchaddons.com/docs/reference/addon-api/addon.self/#getenabledaddons).
 
 Sub-properties:
@@ -273,7 +326,12 @@ Sub-properties:
   }
   ```
 
-## `settings` (object)
+## `settings`
+
+| | |
+| - | - |
+| Type | `Object` |
+
 Settings allow the addon's users to specify settings in Scratch Addons' settings panel. Inside your userscripts, you can then access those settings with the `addon.settings` API.  
 Specify a `settings` property and provide an array of option objects.
 
@@ -368,7 +426,12 @@ Example:
 }
 ```
 
-## `addonPreview` (object)
+## `addonPreview`
+
+| | |
+| - | - |
+| Type | `Object` |
+
 Specifies the type of preview to show above the addon's settings.
 
 Sub-properties:
@@ -383,7 +446,12 @@ Example:
 }
 ```
 
-## `presetPreview` (object)
+## `presetPreview`
+
+| | |
+| - | - |
+| Type | `Object` |
+
 Specifies the type of preview to show inside the preset buttons.
 
 Sub-properties:
@@ -401,7 +469,10 @@ Example:
 }
 ```
 
-## `credits` (array)
+## `credits`
+| | |
+| - | - |
+| Type | `Array` |
 
 You can provide a `credits` array of objects. This attribution is shown in the extension settings.  
 
@@ -429,11 +500,21 @@ Example:
 }
 ```
 
-## `enabledByDefault` (boolean)
+## `enabledByDefault`
+
+| | |
+| - | - |
+| Type | `Boolean` |
+
 You can provide the `enabledByDefault` property and set it to `true` to specify if the addon should be enabled by default. Its default value is `false`.  
 Keep in mind, few addons will be enabled by default. If you want your addon to be enabled by default, please open a discussion issue.
 
-## `info` (array)
+## `info`
+
+| | |
+| - | - |
+| Type | `Array` |
+
 An array of additional information (e.g. warnings, notices) about the addon. Each item of the array is an object consisting of `type` (string) -either `warning` or `notice` - `text` (string) - the text to be displayed - and `id` (string) - the id of the information.
 Example:
 ```json
@@ -453,7 +534,12 @@ Example:
 }
 ```
 
-## `presets` (array)
+## `presets`
+
+| | |
+| - | - |
+| Type | `Array` |
+
 An array of presets for the addon. Each item in the `presets` array should be an object consisting of `name` (string), `id`(string), `description` (string) and `values` (object). The keys in the `values` object should the addon settings ids, and the values should be the values to set the setting with the id of the key to.
 
  
@@ -475,10 +561,20 @@ Example:
 }
 ```
 
-## `libraries` (array)
+## `libraries`
+
+| | |
+| - | - |
+| Type | `Array` |
+
 An array of libraries that the addon uses.
 
-## `popup` (object)
+## `popup`
+
+| | |
+| - | - |
+| Type | `Object` |
+
 When added, creates a new popup tab in the browser popup.
 
 Sub-properties:
@@ -501,19 +597,44 @@ Example:
 }
 ```
 
-## `dynamicDisable` (boolean)
+## `dynamicDisable`
+
+| | |
+| - | - |
+| Type | `Boolean` |
+
 Indicates whether the addon's scripts should be considered disabled when the addon is disabled while the page is running. Defaults to `false`.
 
-## `dynamicEnable` (boolean)
+## `dynamicEnable`
+
+| | |
+| - | - |
+| Type | `Boolean` |
+
 Indicates whether the addon's scripts should be considered enabled when the addon is enabled while the page is running. Defaults to `false`.
 
-## `injectAsStyleElt` (boolean)
+## `injectAsStyleElt`
+
+| | |
+| - | - |
+| Type | `Boolean` |
+
 Indicates whether the addon's userstyles should be injected as style elements rather than link elements. Defaults to `false`.
 
-## `updateUserstylesOnSettingsChange` (boolean)
+## `updateUserstylesOnSettingsChange`
+
+| | |
+| - | - |
+| Type | `Boolean` |
+
 Indicates whether the addon's userstyles should be removed and rematched to the new settings. Defaults to `false`.
 
-## `customCssVariables` (array)
+## `customCssVariables`
+
+| | |
+| - | - |
+| Type | `Array` |
+
 An array of CSS variables that will be set if the addon is enabled. Each item is an object with two properties, both required:
 - `name` (string): the name of the variable. To avoid conflicts between variables with the same name in different addons, the actual name will be `--{addonId}-{name}`, where `{addonId}` is the addon ID converted to camel case and `{name}` is the value of this property.
 - `value`: a *value provider* - a string, number, or an object with a `type` property that defines what the CSS variable will be set to. The possible types are:
@@ -533,7 +654,12 @@ An array of CSS variables that will be set if the addon is enabled. Each item is
   - `makeHsv`: converts a HSV color to RGB. The additional properties are `h`, `s`, and `v`. Each must be a value provider that returns either a number or a color. Colors will be converted to HSV and the value of the relevant component will be used. This allows making a color that uses the hue of one color chosen by the user and the brightness of another.
   - `recolorFilter`: a CSS filter that replaces every color with the result of the `source` color value provider (required).
 
-## `latestUpdate` (object)
+## `latestUpdate`
+
+| | |
+| - | - |
+| Type | `Object` |
+
 Provides information to the settings page about the latest update to this addon. Responsible for the "New options" tag and the New tag on individual addon settings. If not specified, no update-specific tags will be added.
 
 Sub-properties:


### PR DESCRIPTION
Last time WL agreed on this (I forgot which commit to link) so I would merge this at least tommorow.