### PR TITLE
Delete outdated page reference in /changelog

### DIFF
--- a/content/changelog.html
+++ b/content/changelog.html
@@ -8,8 +8,6 @@ description: All notable changes to this project will be documented in this page
 <div class="container">
 	<p>All notable changes to this project will be documented in this page.</p>
 
-	<p><strong>Note:</strong> This changelog is summarised. Check <a href="https://github.com/ScratchAddons/ScratchAddons/blob/changelog-detailed/CHANGELOG.md">the detailed changelog</a> for all of the changes.</p>
-
 	{{< specifics/changelog >}}
 </div>
 


### PR DESCRIPTION
Deletes "<p><strong>Note:</strong> This changelog is summarised. Check <a href="https://github.com/ScratchAddons/ScratchAddons/blob/changelog-detailed/CHANGELOG.md">the detailed changelog</a> for all of the changes.</p>" because we don't update [/ScratchAddons/blob/changelog-detailed/CHANGELOG.md](https://github.com/ScratchAddons/ScratchAddons/blob/changelog-detailed/CHANGELOG.md) anymore and also scratchaddons.com/changelog was never summarized.

We also could change the text and the link if you want to say something there.