### PR TITLE
Add missing Edge store references

### DIFF
--- a/content/docs/develop/getting-started/creating-an-addon.md
+++ b/content/docs/develop/getting-started/creating-an-addon.md
@@ -14,7 +14,7 @@ Make sure to read that article to be familiar with the terminology.
 Or download as ZIP, if you want. In other words, just download the source code locally.
 
 ## Step 3: Load the extension into Chrome
-*Note: Chrome is recommended for working on addons. Nevertheless, addons are expected to work on Firefox and on Edge.*  
+*Note: Chrome is recommended for working on addons. Nevertheless, addons are expected to work on Firefox and Edge.*  
 Now that you have the extension in your filesystem, go to `chrome://extensions` and toggle "developer mode".  
 Click "load unpacked", then select the folder where Scratch Addons is located. If you're having issues with this, make sure to be selecting the folder where `manifest.json` is located.  
 That's it, you loaded the extension! It should look similar to this:  

--- a/content/docs/develop/getting-started/creating-an-addon.md
+++ b/content/docs/develop/getting-started/creating-an-addon.md
@@ -14,7 +14,7 @@ Make sure to read that article to be familiar with the terminology.
 Or download as ZIP, if you want. In other words, just download the source code locally.
 
 ## Step 3: Load the extension into Chrome
-*Note: Chrome is recommended for working on addons. Nevertheless, addons are expected to work on Firefox.*  
+*Note: Chrome is recommended for working on addons. Nevertheless, addons are expected to work on Firefox and on Edge.*  
 Now that you have the extension in your filesystem, go to `chrome://extensions` and toggle "developer mode".  
 Click "load unpacked", then select the folder where Scratch Addons is located. If you're having issues with this, make sure to be selecting the folder where `manifest.json` is located.  
 That's it, you loaded the extension! It should look similar to this:  

--- a/content/docs/faq.md
+++ b/content/docs/faq.md
@@ -93,7 +93,7 @@ Anyway, back to the point. You can contribute in many ways, and some of it is re
 
 - **Leave a review on the stores**
 
-  You can leave us a review about Scratch Addons on [the Chrome extension page](https://chrome.google.com/webstore/detail/fbeffbjdlemaoicjdapfpikkikjoneco) or [the Firefox addon page](https://addons.mozilla.org/firefox/addon/scratch-messaging-extension/).
+  You can leave us a review about Scratch Addons on [the Chrome extension page](https://chrome.google.com/webstore/detail/fbeffbjdlemaoicjdapfpikkikjoneco), [the Firefox addon page](https://addons.mozilla.org/firefox/addon/scratch-messaging-extension/) or the [Microsoft Edge addon page](https://microsoftedge.microsoft.com/addons/detail/scratch-addons/iliepgjnemckemgnledoipfiilhajdjj).
 
 - **Star our repository**
 

--- a/content/docs/faq.md
+++ b/content/docs/faq.md
@@ -35,7 +35,7 @@ By itself, Scratch Addons is just an addon loader. Its main tasks are:
 
 ### Is Scratch Addons safe? 
 
-Yes. Scratch Addons should not have any security issues in its most recent version. Scratch Addons is an open source project, so the code is constantly being verified by Scratch Addons contributors, as well as by reviewers from the Chrome Web Store and Add-ons for Firefox.
+Yes. Scratch Addons should not have any security issues in its most recent version. Scratch Addons is an open source project, so the code is constantly being verified by Scratch Addons contributors, as well as by reviewers from the Chrome Web Store, Add-ons for Firefox and Microsoft Edge Add-ons.
 
 ### How can I report a security vulnerability?
 

--- a/content/docs/getting-started/installing.md
+++ b/content/docs/getting-started/installing.md
@@ -52,7 +52,7 @@ If you don't have Git installed, you can try this method instead. Note that you 
 
 3. Extract the archive into a folder.
 
-### Installing on Google Chrome
+### Installing on Google Chrome or Microsoft Edge
 
 1. Type `chrome://extensions` into your address bar to open the Extension Management page.
 

--- a/content/docs/policies/privacy/extension.md
+++ b/content/docs/policies/privacy/extension.md
@@ -60,7 +60,7 @@ Permanently-stored information might include:
 
 The extension by itself does not send any of this information outside of your device. 
 
-However, if you enable Chrome Sync, Firefox Sync, or any other compatible browser data synchronization feature, this information might be sent to that service by your browser.
+However, if you enable Chrome Sync, Firefox Sync, Edge Sync, or any other compatible browser data synchronization feature, this information might be sent to that service by your browser.
 
 ## Third Parties
 

--- a/content/docs/policies/privacy/extension.md
+++ b/content/docs/policies/privacy/extension.md
@@ -14,7 +14,7 @@ This page informs you of our policies regarding the collection, use, and disclos
 
 We use your data to provide and improve the service. By using the service, you agree to the collection and use of information in accordance with this policy.
 
-"Extension" refers to our browser extension, which you can download from the [Chrome Web Store](https://chrome.google.com/webstore/detail/fbeffbjdlemaoicjdapfpikkikjoneco) or [Add-ons for Firefox](https://addons.mozilla.org/firefox/addon/scratch-messaging-extension/).
+"Extension" refers to our browser extension, which you can download from the [Chrome Web Store](https://chrome.google.com/webstore/detail/fbeffbjdlemaoicjdapfpikkikjoneco), [Add-ons for Firefox](https://addons.mozilla.org/firefox/addon/scratch-messaging-extension/) or [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com/addons/detail/scratch-addons/iliepgjnemckemgnledoipfiilhajdjj).
 
 "The Scratch website" refers to <https://scratch.mit.edu> and all of its subdomains, such as <https://api.scratch.mit.edu> and <https://clouddata.scratch.mit.edu>.  
 
@@ -26,7 +26,7 @@ We use your data to provide and improve the service. By using the service, you a
 
 - **We never send Scratch account information or extension settings outside of your browser.**
 
-  Extension settings only leave your device if you've enabled Chrome/Firefox Sync.
+  Extension settings only leave your device if you've enabled Chrome/Firefox/Edge Sync.
 
 - **By default, the extension only interacts with the Scratch website and this website.**
 

--- a/content/docs/policies/security.md
+++ b/content/docs/policies/security.md
@@ -5,9 +5,9 @@ weight: 2
 
 ## Supported Versions
 
-Scratch Addons should not have any security issues in its most recent version, found in the Chrome Web Store and Addons for Firefox.
+Scratch Addons should not have any security issues in its most recent version, found in the Chrome Web Store, Add-ons for Firefox and Microsoft Edge Add-ons.
 
-We only officially support the most recent stable versions of Chrome and Firefox. However, if you found a vulnerability that only occurs if using an old browser version, please report it (see below).
+We only officially support the most recent stable versions of Chrome, Firefox and Edge. However, if you found a vulnerability that only occurs if using an old browser version, please report it (see below).
 
 ## Reporting a Vulnerability
 

--- a/content/docs/reference/addon-api/addon.tab/_index.md
+++ b/content/docs/reference/addon-api/addon.tab/_index.md
@@ -268,7 +268,7 @@ If you want to manually hide the element in situations where the addon is enable
 
 Copies a PNG image to the clipboard.  
 Only run this in response of the user explicitly pressing Ctrl+C.  
-Internally uses `browser.clipboard.setImageData` in Firefox and `navigator.clipboard.write` in Chrome.
+Internally uses `browser.clipboard.setImageData` in Firefox and `navigator.clipboard.write` in Chrome and Edge.
 
 ### `addon.tab.scratchClass`
 <table>

--- a/content/farewell.html
+++ b/content/farewell.html
@@ -9,7 +9,7 @@ description: Scratch Addons has been uninstalled. We thank you for using the ext
 </section>
 
 <section class="container">
-    <p>You may reinstall the extension by clicking the install button above. You can also leave a review on on <a href="https://chrome.google.com/webstore/detail/fbeffbjdlemaoicjdapfpikkikjoneco">the Chrome extension page</a>, <a href="https://addons.mozilla.org/firefox/addon/scratch-messaging-extension/">the Firefox addon page</a> or <a href="https://microsoftedge.microsoft.com/addons/detail/scratch-addons/iliepgjnemckemgnledoipfiilhajdjj">the Microsoft Edge addon page</a>.</p>
+    <p>You may reinstall the extension by clicking the install button above. You can also leave a review on <a href="https://chrome.google.com/webstore/detail/fbeffbjdlemaoicjdapfpikkikjoneco">the Chrome extension page</a>, <a href="https://addons.mozilla.org/firefox/addon/scratch-messaging-extension/">the Firefox addon page</a> or <a href="https://microsoftedge.microsoft.com/addons/detail/scratch-addons/iliepgjnemckemgnledoipfiilhajdjj">the Microsoft Edge addon page</a>.</p>
     <p>Based of your reasons of uninstalling the extension, here are some other things that you can do.</p>
     <ul>
         <li>Having problems? Please tell us <a href='{{< ref "/feedback" >}}'>here</a> or create an issue <a href="https://github.com/ScratchAddons/ScratchAddons/issues">here</a>.</li>

--- a/content/farewell.html
+++ b/content/farewell.html
@@ -9,7 +9,7 @@ description: Scratch Addons has been uninstalled. We thank you for using the ext
 </section>
 
 <section class="container">
-    <p>You may reinstall the extension by clicking the install button above. You can also leave a review on <a href="https://chrome.google.com/webstore/detail/fbeffbjdlemaoicjdapfpikkikjoneco">the Chrome extension page</a> or <a href="https://addons.mozilla.org/firefox/addon/scratch-messaging-extension/">the Firefox addon page</a>.</p>
+    <p>You may reinstall the extension by clicking the install button above. You can also leave a review on on <a href="https://chrome.google.com/webstore/detail/fbeffbjdlemaoicjdapfpikkikjoneco">the Chrome extension page</a>, <a href="https://addons.mozilla.org/firefox/addon/scratch-messaging-extension/">the Firefox addon page</a> or <a href="https://microsoftedge.microsoft.com/addons/detail/scratch-addons/iliepgjnemckemgnledoipfiilhajdjj">the Microsoft Edge addon page</a>.</p>
     <p>Based of your reasons of uninstalling the extension, here are some other things that you can do.</p>
     <ul>
         <li>Having problems? Please tell us <a href='{{< ref "/feedback" >}}'>here</a> or create an issue <a href="https://github.com/ScratchAddons/ScratchAddons/issues">here</a>.</li>

--- a/content/welcome.html
+++ b/content/welcome.html
@@ -48,5 +48,5 @@ description: Scratch Addons has been installed successfully! Thank you for insta
 
 <section id="support" class="container mb-4">
 	<h2 class="h4">Want to support us?</h2>
-	<p>You can star our <a href="https://github.com/ScratchAddons/ScratchAddons">repository on GitHub</a> or leave a review on <a href="https://chrome.google.com/webstore/detail/fbeffbjdlemaoicjdapfpikkikjoneco">the Chrome extension page</a> or <a href="https://addons.mozilla.org/firefox/addon/scratch-messaging-extension/">the Firefox addon page</a>.</p>
+	<p>You can star our <a href="https://github.com/ScratchAddons/ScratchAddons">repository on GitHub</a> or leave a review on <a href="https://chrome.google.com/webstore/detail/fbeffbjdlemaoicjdapfpikkikjoneco">the Chrome extension page</a>, <a href="https://addons.mozilla.org/firefox/addon/scratch-messaging-extension/">the Firefox addon page</a> or <a href="https://microsoftedge.microsoft.com/addons/detail/scratch-addons/iliepgjnemckemgnledoipfiilhajdjj">the Microsoft Edge addon page</a>.</p>
 </section>


### PR DESCRIPTION
Now the Scratch Addons extension is also in the Microsoft Edge store, so We should refer to it like we do for Firefox.
Sorry for so many commits.