### PR TITLE
Add pre-send check and warning

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -161,7 +161,16 @@ FeedbackPage:
   ContentPlaceholder: Please provide as much detail as you can.
   SendEnabled: Send list of my currently enabled addons (recommended)
   SubmitButton: Send
-
+  PreSendWarning:
+    Warning: "Warning:"
+    Override: If you are really sure to send this feedback, you can press the "Send" button again.
+    NotST:
+      Heading: We are not the Scratch Team.
+      Description: Keep in mind that Scratch Addons is not affiliated with the Scratch website or the organizations that maintain it. You are still welcome to give ideas to improve your experience on Scratch with Scratch Addons.
+    Punishment:
+      Heading: We can't punish people. We are not the Scratch Team.
+      Description: Scratch Addons is not affiliated with the Scratch website or the organizations that maintain it. We have no control of the content and the moderation on the Scratch website.
+    
 # Strings used for /scratch-messaging-transition
 SMTPage:
   ScratchMessagingLogoAlt: Scratch Messaging Extension logo

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -164,12 +164,13 @@ FeedbackPage:
   PreSendWarning:
     Warning: "Warning:"
     Override: If you are really sure to send this feedback, you can press the "Send" button again.
-    NotST:
-      Heading: We are not the Scratch Team.
-      Description: Keep in mind that Scratch Addons is not affiliated with the Scratch website or the organizations that maintain it. You are still welcome to give ideas to improve your experience on Scratch with Scratch Addons.
-    Punishment:
-      Heading: We can't punish people. We are not the Scratch Team.
-      Description: Scratch Addons is not affiliated with the Scratch website or the organizations that maintain it. We have no control of the content and the moderation on the Scratch website.
+    Variations:
+      NotST:
+        Heading: We are not the Scratch Team.
+        Description: Keep in mind that Scratch Addons is not affiliated with the Scratch website or the organizations that maintain it. You are still welcome to give ideas to improve your experience on Scratch with Scratch Addons.
+      Punishment:
+        Heading: We can't punish people. We are not the Scratch Team. <br>
+        Description: "Scratch Addons is not affiliated with the Scratch website or the organizations that maintain it. We have no control of the content and the moderation on the Scratch website. {{ .Tag1Start }}There are many ways that you can report on the Scratch website.{{ .Tag1End }}"
     
 # Strings used for /scratch-messaging-transition
 SMTPage:

--- a/layouts/shortcodes/specifics/feedback-form.html
+++ b/layouts/shortcodes/specifics/feedback-form.html
@@ -5,7 +5,19 @@
 		statusFailed: '{{ T "FeedbackPage.Status.Failed" }}',
 		statusOffline: '{{ T "FeedbackPage.Status.Offline" }}',
 		noAddonsList: '{{ T "FeedbackPage.NoAddonsList" }}',
-		submitButton: '{{ T "FeedbackPage.SubmitButton" }}',
+		preSendWarning: {
+			warning: '{{ T "FeedbackPage.PreSendWarning.Warning" }}',
+			override: '{{ T "FeedbackPage.PreSendWarning.Override" }}',
+			notST: {
+				heading: '{{ T "FeedbackPage.PreSendWarning.NotST.Heading" }}',
+				description: '{{ T "FeedbackPage.PreSendWarning.NotST.Description" }}',
+			},
+			punishment: {
+				heading: '{{ T "FeedbackPage.PreSendWarning.Punishment.Heading" }}',
+				description: '{{ T "FeedbackPage.PreSendWarning.Punishment.Description" }}',
+			}
+		},
+		submitButton: '{{ T "FeedbackPage.SubmitButton" }}'
 	}
 </script>
 <script defer src="/assets/js/feedback.js"></script>

--- a/layouts/shortcodes/specifics/feedback-form.html
+++ b/layouts/shortcodes/specifics/feedback-form.html
@@ -1,3 +1,5 @@
+{{ $ts := now.UnixMilli }}
+
 <script>
 	window.i18nStrings = {
 		statusSending: '{{ T "FeedbackPage.Status.Sending" }}',
@@ -8,17 +10,20 @@
 		preSendWarning: {
 			warning: '{{ T "FeedbackPage.PreSendWarning.Warning" }}',
 			override: '{{ T "FeedbackPage.PreSendWarning.Override" }}',
-			notST: {
-				heading: '{{ T "FeedbackPage.PreSendWarning.NotST.Heading" }}',
-				description: '{{ T "FeedbackPage.PreSendWarning.NotST.Description" }}',
-			},
-			punishment: {
-				heading: '{{ T "FeedbackPage.PreSendWarning.Punishment.Heading" }}',
-				description: '{{ T "FeedbackPage.PreSendWarning.Punishment.Description" }}',
+			variations: {
+				notST: {
+					heading: '{{ T "FeedbackPage.PreSendWarning.Variations.NotST.Heading" }}',
+					description: '{{ T "FeedbackPage.PreSendWarning.Variations.NotST.Description" | htmlEscape }}',
+				},
+				punishment: {
+					heading: '{{ T "FeedbackPage.PreSendWarning.Variations.Punishment.Heading" }}',
+					description: '{{ T "FeedbackPage.PreSendWarning.Variations.Punishment.Description" ( dict "Tag1Start" (add $ts 1) "Tag1End" (add $ts 2) ) | htmlEscape }}',
+				}
 			}
 		},
 		submitButton: '{{ T "FeedbackPage.SubmitButton" }}'
 	}
+	window.i18nTimestamp = Number('{{ $ts }}')
 </script>
 <script defer src="/assets/js/feedback.js"></script>
 

--- a/static/assets/js/feedback.js
+++ b/static/assets/js/feedback.js
@@ -6,12 +6,12 @@ const notSTWords = [
 const punishmentWords = [
     /\bban\b/,
     /\bunban\b/,
-    /\b(please|pls|plz)\s*block\b/,
+    /\b(please|pl[sz])\s*block\b/,
     /\bkick\b/,
     /\bpunish\b/,
     /\bpunishment\b/,
-    /\bmute\b/,
-    /\bunmute\b/,
+    /\b(please|pl[sz])\s*mute\b/,
+    /\b(please|pl[sz])\s*unmute\b/,
 ]
 
 const i18n = window.i18nStrings

--- a/static/assets/js/feedback.js
+++ b/static/assets/js/feedback.js
@@ -1,14 +1,17 @@
 const notSTWords = [
-    /\bscratch *team\b/i,
+    /\bscratch\s*team\b/i,
     /\bst\b/,
 ]
 
 const punishmentWords = [
     /\bban\b/,
-    /\b(please|pls|plz) *block\b/,
+    /\bunban\b/,
+    /\b(please|pls|plz)\s*block\b/,
     /\bkick\b/,
     /\bpunish\b/,
-    /\bpunishment\b/
+    /\bpunishment\b/,
+    /\bmute\b/,
+    /\bunmute\b/,
 ]
 
 const i18n = window.i18nStrings

--- a/static/assets/js/feedback.js
+++ b/static/assets/js/feedback.js
@@ -4,14 +4,16 @@ const variations = {
         /\bst\b/,
     ],
     punishment: [
-        /\bban\b/,
-        /\bunban\b/,
-        /\b(please|pl[sz])\s*block\b/,
-        /\bkick\b/,
-        /\bpunish\b/,
-        /\bpunishment\b/,
-        /\b(please|pl[sz])\s*mute\b/,
-        /\b(please|pl[sz])\s*unmute\b/,
+        /\bban(ing|ned)?\b/,
+        /\bunban(ing|ned)?\b/,
+        /\bkick(ing|ed)?\b/,
+        /\bpunish(ing|ed|ment)?\b/,
+        /\b(please|pl[sz])\s*block(ing|ed)?\b/,
+        /\b(please|pl[sz])\s*mut(ed?|ing)\b/,
+        /\b(please|pl[sz])\s*unmut(ed?|ing)\b/,
+        /\bblock(ing|ed)?\s*(please|pl[sz])\b/,
+        /\bmut(ed?|ing)\s*(please|pl[sz])\b/,
+        /\bunmut(ed?|ing)\s*(please|pl[sz])\b/,
     ]
 }
 

--- a/static/assets/js/feedback.js
+++ b/static/assets/js/feedback.js
@@ -1,18 +1,19 @@
-const notSTWords = [
-    /\bscratch\s*team\b/i,
-    /\bst\b/,
-]
-
-const punishmentWords = [
-    /\bban\b/,
-    /\bunban\b/,
-    /\b(please|pl[sz])\s*block\b/,
-    /\bkick\b/,
-    /\bpunish\b/,
-    /\bpunishment\b/,
-    /\b(please|pl[sz])\s*mute\b/,
-    /\b(please|pl[sz])\s*unmute\b/,
-]
+const variations = {
+    notST: [
+        /\bscratch\s*team\b/i,
+        /\bst\b/,
+    ],
+    punishment: [
+        /\bban\b/,
+        /\bunban\b/,
+        /\b(please|pl[sz])\s*block\b/,
+        /\bkick\b/,
+        /\bpunish\b/,
+        /\bpunishment\b/,
+        /\b(please|pl[sz])\s*mute\b/,
+        /\b(please|pl[sz])\s*unmute\b/,
+    ]
+}
 
 const i18n = window.i18nStrings
 let lastFeedbackRequestTime = localStorage.getItem("lastFeedbackRequestTime") 
@@ -104,7 +105,7 @@ const setPreSendWarning = (heading, description) => {
     statusEl.appendChild(headingEl)
     headingEl.insertAdjacentHTML('afterbegin', `<b>${i18n.preSendWarning.warning}</b> `)
     const descriptionEl = document.createElement('p')
-    descriptionEl.textContent = description
+    descriptionEl.innerHTML = description
     statusEl.appendChild(descriptionEl)
     const overrideEl = document.createElement('p')
     overrideEl.textContent = i18n.preSendWarning.override
@@ -113,14 +114,23 @@ const setPreSendWarning = (heading, description) => {
     holdSendButton(5)
 }
 
+for (const variation in variations) {
+    const variationObj = i18n.preSendWarning.variations[variation]
+    for (const key in variationObj) {
+        variationObj[key] = DOMPurify.sanitize(variationObj[key])
+    }
+}
+const punishment = i18n.preSendWarning.variations.punishment
+punishment.description = punishment.description.replace(window.i18nTimestamp + 1, '<a href="https://en.scratch-wiki.info/wiki/Report">').replace(window.i18nTimestamp + 2, '</a>')
+
 const preSendCheck = content => {
     content = content.toLowerCase()
     let warningText = false
-    if (notSTWords.some(el => content.search(el) + 1)) {
-        warningText = [i18n.preSendWarning.notST.heading, i18n.preSendWarning.notST.description]
-    }
-    if (punishmentWords.some(el => content.search(el) + 1)) {
-        warningText = [i18n.preSendWarning.punishment.heading, i18n.preSendWarning.punishment.description]
+    for (var variation in variations) {
+        if (variations[variation].some(el => content.search(el) + 1)) {
+            warningText = [i18n.preSendWarning.variations[variation].heading, i18n.preSendWarning.variations[variation].description]
+            break
+        }
     }
     if (warningText) {
         if (hasWarnedContent && hasWarnedContent === content) {

--- a/static/assets/js/feedback.js
+++ b/static/assets/js/feedback.js
@@ -1,3 +1,16 @@
+const notSTWords = [
+    /\bscratch *team\b/i,
+    /\bst\b/,
+]
+
+const punishmentWords = [
+    /\bban\b/,
+    /\b(please|pls|plz) *block\b/,
+    /\bkick\b/,
+    /\bpunish\b/,
+    /\bpunishment\b/
+]
+
 const i18n = window.i18nStrings
 let lastFeedbackRequestTime = localStorage.getItem("lastFeedbackRequestTime") 
 let wakeUpTimeout = setTimeout(() => {}, 0)
@@ -100,12 +113,10 @@ const setPreSendWarning = (heading, description) => {
 const preSendCheck = content => {
     content = content.toLowerCase()
     let warningText = false
-    const notSTWords = 'scratch team,st'.split(',')
-    if (notSTWords.some(el => content.includes(el))) {
+    if (notSTWords.some(el => content.search(el) + 1)) {
         warningText = [i18n.preSendWarning.notST.heading, i18n.preSendWarning.notST.description]
     }
-    const punishmentWords = 'ban,block,kick,punish,punishment'.split(',')
-    if (punishmentWords.some(el => content.includes(el))) {
+    if (punishmentWords.some(el => content.search(el) + 1)) {
         warningText = [i18n.preSendWarning.punishment.heading, i18n.preSendWarning.punishment.description]
     }
     if (warningText) {


### PR DESCRIPTION
As it says, it adds a pre-send check and warning, which checks the message before sending and puts a warning if one or more keywords are detected on the feedback content.

The current form is quite preliminary, and may be improved on this PR based on necessity. Everyone that had access is welcome to edit it.

