### PR TITLE
Add contributing guidelines link to new addon FAQ page

### DIFF
--- a/content/docs/develop/getting-started/creating-an-addon.md
+++ b/content/docs/develop/getting-started/creating-an-addon.md
@@ -78,5 +78,5 @@ Make sure your addon doesn't break other addons.
 Make sure your code is understandable; having unnecessary comments is better than no comments.
 
 ## Step 12: Send a pull request!
-Follow the steps on our [contributing guidelines](https://github.com/ScratchAddons/ScratchAddons/blob/master/CONTRIBUTING.md) to send a PR with your new addon! 
+Follow the steps on our [contributing guidelines](https://github.com/ScratchAddons/ScratchAddons/blob/master/CONTRIBUTING.md). Simply put, fork the repo if you haven't already, commit your new addon and send a PR!  
 Keep in mind we might request you to make some changes, however, we will probably accept your addon as long as it's minimally suitable.

--- a/content/docs/develop/getting-started/creating-an-addon.md
+++ b/content/docs/develop/getting-started/creating-an-addon.md
@@ -78,5 +78,5 @@ Make sure your addon doesn't break other addons.
 Make sure your code is understandable; having unnecessary comments is better than no comments.
 
 ## Step 12: Send a pull request!
-Fork the repo if you haven't already, commit your new addon and send a PR!  
+Follow the steps on our [contributing guidelines](https://github.com/ScratchAddons/ScratchAddons/blob/master/CONTRIBUTING.md) to send a PR with your new addon! 
 Keep in mind we might request you to make some changes, however, we will probably accept your addon as long as it's minimally suitable.


### PR DESCRIPTION
Related to https://github.com/ScratchAddons/ScratchAddons/issues/5075

### Changes

Adds a link to the CONTRIBUTING.md file from ScratchAddons/ScratchAddons.

### Reason for changes

"Fork the repo if you haven't already, commit your new addon and send a PR" alone sounded a bit incomplete, so I thought it was time we provide proper instructions to anyone who's new here.