### PR TITLE
Add no_comments:true to policy docs

### DIFF
--- a/content/docs/policies/chrome-web-store-privacy-information.md
+++ b/content/docs/policies/chrome-web-store-privacy-information.md
@@ -5,6 +5,7 @@ weight: 100
 aliases:
   - /docs/chrome-web-store-privacy-information
   - /docs/policies/chrome-web-store-privacy-information
+no_comments: true
 ---
 
 This is how we fill the "privacy practices" form on the Chrome Web Store Developer Dashboard.

--- a/content/docs/policies/code-of-conduct.md
+++ b/content/docs/policies/code-of-conduct.md
@@ -2,6 +2,7 @@
 title: Contributor Covenant Code of Conduct
 toc_title: Code of Conduct
 weight: 3
+no_comments: true
 ---
 
 ## Our Pledge

--- a/content/docs/policies/security.md
+++ b/content/docs/policies/security.md
@@ -1,6 +1,7 @@
 ---
 title: Security Policy
 weight: 2
+no_comments: true
 ---
 
 ## Supported Versions


### PR DESCRIPTION
You can't comment below the code of conduct