### PR TITLE
Documentation: add warning to "creating an addon"

### DIFF
--- a/content/docs/develop/getting-started/creating-an-addon.md
+++ b/content/docs/develop/getting-started/creating-an-addon.md
@@ -8,7 +8,7 @@ Required software: text editor, Chrome.
 If possible, disable the Scratch Addons extension you downloaded from the store before proceeding to avoid issues.
 
 
-{{< admonition error >}}
+{{< admonition info >}}
 If you plan to submit the addon you are developing as a pull request to our GitHub repository, please read our [contributing guidelines](https://github.com/ScratchAddons/ScratchAddons/blob/master/.github/CONTRIBUTING.md) first. 
 
 In case there is no existing GitHub issue in that repository related to your new addon idea, please [create one](https://github.com/ScratchAddons/ScratchAddons/issues/new/choose). However, if there is already an issue related to your feature idea, we suggest that you leave a comment on it stating your intention to develop the addon. This will enable other contributors to provide feedback on whether the addon could be accepted, or if further discussion is required.

--- a/content/docs/develop/getting-started/creating-an-addon.md
+++ b/content/docs/develop/getting-started/creating-an-addon.md
@@ -7,6 +7,15 @@ aliases:
 Required software: text editor, Chrome.  
 If possible, disable the Scratch Addons extension you downloaded from the store before proceeding to avoid issues.
 
+
+{{< admonition error >}}
+If you plan to submit the addon you are developing as a pull request to our GitHub repository, please read our [contributing guidelines](https://github.com/ScratchAddons/ScratchAddons/blob/master/.github/CONTRIBUTING.md) first. 
+
+In case there is no existing GitHub issue in that repository related to your new addon idea, please [create one](https://github.com/ScratchAddons/ScratchAddons/issues/new/choose). However, if there is already an issue related to your feature idea, we suggest that you leave a comment on it stating your intention to develop the addon. This will enable other contributors to provide feedback on whether the addon could be accepted, or if further discussion is required.
+
+However, if you are creating an addon for personal use, you may proceed with this guide.
+{{< /admonition >}}
+
 ## Step 1: Read about [addon basics](/docs/develop/getting-started/addon-basics/)
 Make sure to read that article to be familiar with the terminology.
 


### PR DESCRIPTION
Links to the contributing guidelines, in case the reader intends to submit their addon instead of creating it for personal use or for other purposes.

The rest of the article should be re-written at some point.