### PR TITLE
Add pre-send warning for the customizable block colors crash

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -171,9 +171,9 @@ FeedbackPage:
       Punishment:
         Heading: We can't punish people. We are not the Scratch Team.
         Description: "Scratch Addons is not affiliated with the Scratch website or the organizations that maintain it. We have no control of the content and the moderation on the Scratch website. {{ .Tag1Start }}There are many ways that you can report on the Scratch website.{{ .Tag1End }}"
-      BackpackBug:
-        Heading: Disable the "Faster project loading" addon.
-        Description: "There is a known bug with the \"Faster project loading\" addon that prevents you from putting sprites out of your backpack. For now, try disabling that addon until your browser gets the v1.32.1 update."
+      Theme3CrashBug:
+        Heading: There is a known bug with the "Customizable block colors" addon.
+        Description: "If you're experiencing a crash when trying to create a custom block, this is a known bug with the \"Customizable block colors\" addon. For now, try disabling that addon until this is fixed (likely next release)."
 
 # Strings used for /scratch-messaging-transition
 SMTPage:

--- a/layouts/shortcodes/specifics/feedback-form.html
+++ b/layouts/shortcodes/specifics/feedback-form.html
@@ -19,9 +19,9 @@
 					heading: '{{ T "FeedbackPage.PreSendWarning.Variations.Punishment.Heading" }}',
 					description: '{{ T "FeedbackPage.PreSendWarning.Variations.Punishment.Description" ( dict "Tag1Start" (add $ts 1) "Tag1End" (add $ts 2) ) | htmlEscape }}',
 				},
-				backpackBug: {
-					heading: '{{ T "FeedbackPage.PreSendWarning.Variations.BackpackBug.Heading" }}',
-					description: '{{ T "FeedbackPage.PreSendWarning.Variations.BackpackBug.Description" | htmlEscape }}',
+				theme3CrashBug: {
+					heading: '{{ T "FeedbackPage.PreSendWarning.Variations.Theme3CrashBug.Heading" }}',
+					description: '{{ T "FeedbackPage.PreSendWarning.Variations.Theme3CrashBug.Description" | htmlEscape }}',
 				}
 			}
 		},

--- a/static/assets/js/feedback.js
+++ b/static/assets/js/feedback.js
@@ -29,12 +29,12 @@ const variations = {
             /\bunmut(ed?|ing)\s*(please|pl[sz])\b/,
         ]
     },
-    backpackBug: {
+    theme3CrashBug: {
         strings: {
-            ...i18n.preSendWarning.variations.backpackBug
+            ...i18n.preSendWarning.variations.theme3CrashBug
         },
         patterns: [
-            /\bback ?pack\b/,
+            /\b(?:crash(?:es|ing)?|mak(?:e|ing|eing)|creat(?:e|ing|eing)?|new blocks?|my blocks?|custom blocks?)\b/,
         ]
     },
 }
@@ -193,7 +193,7 @@ form.addEventListener("submit", async event => {
     if (preSendCheck(contentField.value)) {
         try {
             lastFeedbackRequestTime = Date.now()
-            localStorage.setItem("lastFeedbackRequestTime", lastFeedbackRequestTime)    
+            localStorage.setItem("lastFeedbackRequestTime", lastFeedbackRequestTime)
             const res = await fetch("https://scratchaddons-feedback.glitch.me/send", {
                 method: "POST", 
                 body: JSON.stringify(body)


### PR DESCRIPTION

![image](https://github.com/ScratchAddons/website-v2/assets/68464103/4f6d7697-c279-424f-b7d6-8cce35d37dd7)

Triggers on words: 
`crash(es|ing)` `make(ing|eing)` `create(ing|eing)` `creat` `new block(s)` `my block(s)` `custom block(s)`

Also removes the backpack bug warning, since I'd expect most people have updated to 1.32.1 or 1.33.0 now.