### PR TITLE
Misc doc updates

### DIFF
--- a/content/docs/develop/userscripts/best-practices.md
+++ b/content/docs/develop/userscripts/best-practices.md
@@ -111,6 +111,7 @@ reportButton.addEventListener("click", (event) => {
 
 - Prefer newer APIs, such as `fetch()` over `XMLHttpRequest`.
 - Never use `==` for comparisons. Use `===` instead.
+- Avoid `keyCode`, use `event.key` instead.
 - Use optional chaining if an object can sometimes be `null`.  
 For example, `document.querySelector(".remix-button")?.textContent`.
 - Use `for ... of` loops or `.forEach()`.  

--- a/content/docs/develop/userscripts/best-practices.md
+++ b/content/docs/develop/userscripts/best-practices.md
@@ -111,7 +111,7 @@ reportButton.addEventListener("click", (event) => {
 
 - Prefer newer APIs, such as `fetch()` over `XMLHttpRequest`.
 - Never use `==` for comparisons. Use `===` instead.
-- Avoid `keyCode`, use `event.key` instead.
+- When listening to keyboard events, accessing `event.key` is the preferred way to know which key was pressed. In general, you should avoid `event.code` and `event.keyCode`.
 - Use optional chaining if an object can sometimes be `null`.  
 For example, `document.querySelector(".remix-button")?.textContent`.
 - Use `for ... of` loops or `.forEach()`.  

--- a/content/docs/faq.md
+++ b/content/docs/faq.md
@@ -37,7 +37,7 @@ Scratch Addons is officially supported on the desktop versions of [Google Chrome
 
 ### Can I use Scratch Addons on a mobile device?
 
-**For Android users**: Yes, Scratch Addons can now be installed on [Firefox for Android](https://play.google.com/store/apps/details?id=org.mozilla.firefox) (desktop site may need to be toggled on), but it is not recommended yet since Scratch Addons' UI is not well-tested on touchscreens or environments with small screen sizes so some features might not work as expected. Alternatively, if you prefer Chrome you can try [Kiwi](https://kiwibrowser.com/).
+**For Android users**: Yes, Scratch Addons can now be installed on [Firefox for Android](https://play.google.com/store/apps/details?id=org.mozilla.firefox) (desktop site may need to be enabled), but it is not recommended yet since Scratch Addons' UI is not well-tested on touchscreens or environments with small screen sizes so some features might not work as expected. Alternatively, if you prefer Chrome you could try the [Kiwi Browser](https://kiwibrowser.com/).
 
 **For iOS and iPadOS users**: Sadly, it is not. App Store policy does not allow browser implementations to be uploaded, which means all browsers available on that platform are just re-skinned Safari. This causes some problems (see below).
 

--- a/content/docs/faq.md
+++ b/content/docs/faq.md
@@ -37,7 +37,7 @@ Scratch Addons is officially supported on the desktop versions of [Google Chrome
 
 ### Can I use Scratch Addons on a mobile device?
 
-**For Android users**: Yes, Scratch Addons can now be installed on [Firefox for Android](https://play.google.com/store/apps/details?id=org.mozilla.firefox), but it is not recommended yet since Scratch Addons' UI is not well-tested on touchscreens or environments with small screen sizes so some features might not work as expected. Alternatively, if you prefer Chrome you can try [Kiwi](https://kiwibrowser.com/).
+**For Android users**: Yes, Scratch Addons can now be installed on [Firefox for Android](https://play.google.com/store/apps/details?id=org.mozilla.firefox) (desktop site may need to be toggled on), but it is not recommended yet since Scratch Addons' UI is not well-tested on touchscreens or environments with small screen sizes so some features might not work as expected. Alternatively, if you prefer Chrome you can try [Kiwi](https://kiwibrowser.com/).
 
 **For iOS and iPadOS users**: Sadly, it is not. App Store policy does not allow browser implementations to be uploaded, which means all browsers available on that platform are just re-skinned Safari. This causes some problems (see below).
 

--- a/content/docs/faq.md
+++ b/content/docs/faq.md
@@ -37,7 +37,7 @@ Scratch Addons is officially supported on the desktop versions of [Google Chrome
 
 ### Can I use Scratch Addons on a mobile device?
 
-**For Android users**: Yes, Scratch Addons can now be installed on [Firefox for Android](https://play.google.com/store/apps/details?id=org.mozilla.firefox) (desktop site may need to be enabled), but it is not recommended yet since Scratch Addons' UI is not well-tested on touchscreens or environments with small screen sizes so some features might not work as expected. Alternatively, if you prefer Chrome you could try the [Kiwi Browser](https://kiwibrowser.com/).
+**For Android users**: Yes, Scratch Addons can now be installed on [Firefox for Android](https://play.google.com/store/apps/details?id=org.mozilla.firefox), but it is not recommended yet since Scratch Addons' UI is not well-tested on touchscreens or environments with small screen sizes so some features might not work as expected. Alternatively, if you prefer Chrome you could try the [Kiwi Browser](https://kiwibrowser.com/).
 
 **For iOS and iPadOS users**: Sadly, it is not. App Store policy does not allow browser implementations to be uploaded, which means all browsers available on that platform are just re-skinned Safari. This causes some problems (see below).
 

--- a/content/docs/faq.md
+++ b/content/docs/faq.md
@@ -37,9 +37,9 @@ Scratch Addons is officially supported on the desktop versions of [Google Chrome
 
 ### Can I use Scratch Addons on a mobile device?
 
-For Android users: Yes, but it is not recommended. Major browsers do not allow Scratch Addons (or any other extensions) to be installed, so you need to use browsers such as [Kiwi](https://kiwibrowser.com/) to do so. Scratch Addons' UI is not well-tested on touchscreens or environments with small screen size, so some of the features might not work as expected.
+**For Android users**: Yes, Scratch Addons can now be installed on [Firefox for Android](https://play.google.com/store/apps/details?id=org.mozilla.firefox), but it is not recommended yet since Scratch Addons' UI is not well-tested on touchscreens or environments with small screen sizes so some features might not work as expected. Alternatively, if you prefer Chrome you can try [Kiwi](https://kiwibrowser.com/).
 
-For iOS and iPadOS users: Sadly, it is not. App Store policy does not allow browser implementations to be uploaded, which means all browsers available on that platform are just re-skinned Safari. This causes some problems (see below).
+**For iOS and iPadOS users**: Sadly, it is not. App Store policy does not allow browser implementations to be uploaded, which means all browsers available on that platform are just re-skinned Safari. This causes some problems (see below).
 
 ### Can I use Scratch Addons on Safari?
 

--- a/content/docs/reference/addon-api/addon.tab/_index.md
+++ b/content/docs/reference/addon-api/addon.tab/_index.md
@@ -31,7 +31,7 @@ while (true) {
 ### Using `addon.tab.displayNoneWhileDisabled` (`dynamicDisable`)
 We use `addon.tab.displayNoneWhileDisabled` to hide an image when the addon gets disabled.  
 We create a button to hide the image when clicked, and the image succesfully gets hidden, even if the addon is enabled.  
-We also set the `display` CSS property of the image to `flex` when visible, even tho that is not the default value for images.
+We also set the `display` CSS property of the image to `flex` when visible, even though that is not the default value for images.
 ```js
   /* userscript.js */
   const img = document.createElement("img");

--- a/content/docs/reference/addon-manifest.md
+++ b/content/docs/reference/addon-manifest.md
@@ -368,6 +368,7 @@ Sub-properties:
 - `type` (string, required) Either `boolean` (an on/off toggle), `positive_integer` (an input box that only allows 0 and above), `integer` (an input box that allows any integer) `string` (up to 100 chars),`color` (a browser color input that returns a hex code), `table` (list of elements, where user can add custom elements, remove existing ones and change order of them) or `select` (see `potential_values`).  
 - `default` (string, required) The default value for the option. A boolean, string, or number, depending on the specified type.  
 - `min`/`max` (number, optional for `positive_integer`, `integer`, and `string` types only) For integers, the minimum/maximum value allowed, and for strings, the minimum/maximum allowed length of the value.
+- `untranslated` (boolean, optional for `string` type only) Whether the value of `default` should not be sent for tranlations. By default it is.
 - `potentialValues` (array of objects, required for `select` type only) Array of objects, with properties `id`, the value received from `addon.settings.get()`, and `name`, the user-visible option text.
 - `allowTransparency` (boolean, required for `color` type only) Whether the user should be allowed to enter transparent colors or not.
 - `row` (array of objects, only for `table` type). Every element in table contains this array of objects. Each object should contain: `name`, `id`, `type` (any setting type other than `table`) and `default`. For example:

--- a/content/docs/reference/addon-manifest.md
+++ b/content/docs/reference/addon-manifest.md
@@ -363,9 +363,17 @@ Settings allow the addon's users to specify settings in Scratch Addons' settings
 Specify a `settings` property and provide an array of option objects.
 
 Sub-properties:
-- `name` (string, required) The user-visible text for the option.   
-- `id` (string, required) An identifier to get the user-specified value from your code.  
-- `type` (string, required) Either `boolean` (an on/off toggle), `positive_integer` (an input box that only allows 0 and above), `integer` (an input box that allows any integer) `string` (up to 100 chars), `untranslated` (a string that isn't send for translation), `color` (a browser color input that returns a hex code), `table` (list of elements, where user can add custom elements, remove existing ones and change order of them) or `select` (see `potential_values`).
+- `name` (string, required) The user-visible text for the option.
+- `id` (string, required) An identifier to get the user-specified value from your code.
+- `type` (string, required) The type of input presented to the user. It can be one of the following:
+  - `boolean`: An on/off toggle
+  - `integer`: An input box that allows any integer
+  - `positive_integer`: An input box that only allows 0 and above
+  - `string`: A string up to 100 characters long
+  - `untranslated`: A string that isn't sent for translation
+  - `color`: A browser color input that returns a hex code
+  - `table`: A list of elements, where the user can add custom elements, remove existing ones and change order of them
+  - `select`: See `potential_values`
 - `default` (string, required) The default value for the option. A boolean, string, or number, depending on the specified type.  
 - `min`/`max` (number, optional for `positive_integer`, `integer`, and `string` types only) For integers, the minimum/maximum value allowed, and for strings, the minimum/maximum allowed length of the value.
 - `potentialValues` (array of objects, required for `select` type only) Array of objects, with properties `id`, the value received from `addon.settings.get()`, and `name`, the user-visible option text.

--- a/content/docs/reference/addon-manifest.md
+++ b/content/docs/reference/addon-manifest.md
@@ -363,8 +363,8 @@ Settings allow the addon's users to specify settings in Scratch Addons' settings
 Specify a `settings` property and provide an array of option objects.
 
 Sub-properties:
-- `name` (string, required) The user-visible text for the option.
-- `id` (string, required) An identifier to get the user-specified value from your code.
+- `name` (string, required) The user-visible text for the option.   
+- `id` (string, required) An identifier to get the user-specified value from your code.  
 - `type` (string, required) The type of input presented to the user. It can be one of the following:
   - `boolean`: An on/off toggle
   - `integer`: An input box that allows any integer

--- a/content/docs/reference/addon-manifest.md
+++ b/content/docs/reference/addon-manifest.md
@@ -368,7 +368,7 @@ Sub-properties:
 - `type` (string, required) Either `boolean` (an on/off toggle), `positive_integer` (an input box that only allows 0 and above), `integer` (an input box that allows any integer) `string` (up to 100 chars),`color` (a browser color input that returns a hex code), `table` (list of elements, where user can add custom elements, remove existing ones and change order of them) or `select` (see `potential_values`).  
 - `default` (string, required) The default value for the option. A boolean, string, or number, depending on the specified type.  
 - `min`/`max` (number, optional for `positive_integer`, `integer`, and `string` types only) For integers, the minimum/maximum value allowed, and for strings, the minimum/maximum allowed length of the value.
-- `untranslated` (boolean, optional for `string` type only) Whether the value of `default` should not be sent for tranlations. By default it is.
+- `untranslated` (boolean, optional for `string` type only) Whether the value of `default` should be sent for tranlations. By default it is.
 - `potentialValues` (array of objects, required for `select` type only) Array of objects, with properties `id`, the value received from `addon.settings.get()`, and `name`, the user-visible option text.
 - `allowTransparency` (boolean, required for `color` type only) Whether the user should be allowed to enter transparent colors or not.
 - `row` (array of objects, only for `table` type). Every element in table contains this array of objects. Each object should contain: `name`, `id`, `type` (any setting type other than `table`) and `default`. For example:

--- a/content/docs/reference/addon-manifest.md
+++ b/content/docs/reference/addon-manifest.md
@@ -365,10 +365,9 @@ Specify a `settings` property and provide an array of option objects.
 Sub-properties:
 - `name` (string, required) The user-visible text for the option.   
 - `id` (string, required) An identifier to get the user-specified value from your code.  
-- `type` (string, required) Either `boolean` (an on/off toggle), `positive_integer` (an input box that only allows 0 and above), `integer` (an input box that allows any integer) `string` (up to 100 chars),`color` (a browser color input that returns a hex code), `table` (list of elements, where user can add custom elements, remove existing ones and change order of them) or `select` (see `potential_values`).  
+- `type` (string, required) Either `boolean` (an on/off toggle), `positive_integer` (an input box that only allows 0 and above), `integer` (an input box that allows any integer) `string` (up to 100 chars), `untranslated` (a string that isn't send for translation), `color` (a browser color input that returns a hex code), `table` (list of elements, where user can add custom elements, remove existing ones and change order of them) or `select` (see `potential_values`).
 - `default` (string, required) The default value for the option. A boolean, string, or number, depending on the specified type.  
 - `min`/`max` (number, optional for `positive_integer`, `integer`, and `string` types only) For integers, the minimum/maximum value allowed, and for strings, the minimum/maximum allowed length of the value.
-- `untranslated` (boolean, optional for `string` type only) Whether the value of `default` should be sent for tranlations. By default it is.
 - `potentialValues` (array of objects, required for `select` type only) Array of objects, with properties `id`, the value received from `addon.settings.get()`, and `name`, the user-visible option text.
 - `allowTransparency` (boolean, required for `color` type only) Whether the user should be allowed to enter transparent colors or not.
 - `row` (array of objects, only for `table` type). Every element in table contains this array of objects. Each object should contain: `name`, `id`, `type` (any setting type other than `table`) and `default`. For example:


### PR DESCRIPTION
- fixes a typo @Jazza-231 reported
- documents `untranslated`
- Turns `type` into a list
- Recommend Firefox for Android in the FAQ leaving Kiwi as an alternative
- Use `e.key` instead of `keyCode`