### PR TITLE
Add "export settings" button to unsupported-browser page

### DIFF
--- a/content/unsupported-browser.html
+++ b/content/unsupported-browser.html
@@ -18,8 +18,8 @@ robots_tag: noindex
 <section class="mb-5">
   <p>Your browser is not supported by Scratch Addons.</p>
   <div id="export-settings" style="display: none">
-    <button id="export-btn" class="btn dark-btn-white">Export my extension settings</button>
-    <button id="export-view-btn" class="btn dark-btn-white">View my extension settings</button>
+    <button id="export-btn" class="btn btn-dark dark-btn-white">Export my extension settings</button>
+    <button id="export-view-btn"class="btn btn-dark dark-btn-white">View my extension settings</button>
     <p>After updating your browser, you can import your settings by going to Scratch Addons settings > More Settings > Import settings.</p>
   </div>
 </section>

--- a/content/unsupported-browser.html
+++ b/content/unsupported-browser.html
@@ -20,11 +20,11 @@ robots_tag: noindex
 
 <section class="mb-3">
   <p>Please update your browser to use Scratch Addons. We recommend exporting your settings before doing so.</p>
-  <div id="export-settings" style="display: none">
-    <button id="export-btn" class="btn btn-dark dark-btn-white">Export my extension settings</button>
-    <button id="export-view-btn" class="btn btn-dark dark-btn-white">View my extension settings</button>
+  <p id="export-settings" style="display: none">
+    <button id="export-btn" class="btn btn-primary">Export my extension settings</button>
+    <button id="export-view-btn" class="btn btn-primary">View my extension settings</button>
     <p>After updating your browser, you can import your settings by going to Scratch Addons settings > More Settings > Import settings.</p>
-  </div>
+  </p>
 </section>
 
 <hr>

--- a/content/unsupported-browser.html
+++ b/content/unsupported-browser.html
@@ -19,7 +19,7 @@ robots_tag: noindex
   <p>Your browser is not supported by Scratch Addons.</p>
   <div id="export-settings" style="display: none">
     <button id="export-btn" class="btn btn-dark dark-btn-white">Export my extension settings</button>
-    <button id="export-view-btn"class="btn btn-dark dark-btn-white">View my extension settings</button>
+    <button id="export-view-btn" class="btn btn-dark dark-btn-white">View my extension settings</button>
     <p>After updating your browser, you can import your settings by going to Scratch Addons settings > More Settings > Import settings.</p>
   </div>
 </section>

--- a/content/unsupported-browser.html
+++ b/content/unsupported-browser.html
@@ -4,6 +4,8 @@ description: Scratch Addons doesn't support the browser you're using.
 robots_tag: noindex
 ---
 
+<script defer src="/assets/js/unsupported-browser.js"></script>
+
 <section id="intro" class="intro-heading">
   <h1 class="mb-3">Unsupported Browser</h1>
   <p class="mb-1">
@@ -11,8 +13,19 @@ robots_tag: noindex
   </p>
 </section>
 
-<section class="container">
-  <p>Use updated versions of Chrome, Firefox, or other browsers based on them to get started:</p>
+<div class="container">
+
+<section class="mb-5">
+  <p>Your browser is not supported by Scratch Addons.</p>
+  <div id="export-settings" style="display: none">
+    <button id="export-btn" class="btn dark-btn-white">Export my extension settings</button>
+    <button id="export-view-btn" class="btn dark-btn-white">View my extension settings</button>
+    <p>After updating your browser, you can import your settings by going to Scratch Addons settings > More Settings > Import settings.</p>
+  </div>
+</section>
+
+<section>
+  <p>These are the browsers we currently support.</p>
   <br>
   <h4>
     <span class="iconify-inline" data-icon="simple-icons:googlechrome"></span> Chromium 80+
@@ -70,6 +83,8 @@ robots_tag: noindex
     <span class="iconify-inline" data-icon="simple-icons:apple"></span> OS X / MacOS 10.12+
   </p>
 </section>
+
+</div>
 
 <style>
   table.browserlist td:nth-child(1) {

--- a/content/unsupported-browser.html
+++ b/content/unsupported-browser.html
@@ -15,7 +15,7 @@ robots_tag: noindex
 
 <div class="container">
 
-<section class="mb-5">
+<section class="mb-3">
   <p>Please update your browser to use Scratch Addons. We recommend exporting your settings before doing so.</p>
   <div id="export-settings" style="display: none">
     <button id="export-btn" class="btn btn-dark dark-btn-white">Export my extension settings</button>
@@ -23,6 +23,8 @@ robots_tag: noindex
     <p>After updating your browser, you can import your settings by going to Scratch Addons settings > More Settings > Import settings.</p>
   </div>
 </section>
+
+<hr>
 
 <section>
   <p>These are the browsers we currently support.</p>

--- a/content/unsupported-browser.html
+++ b/content/unsupported-browser.html
@@ -16,7 +16,7 @@ robots_tag: noindex
 <div class="container">
 
 <section class="mb-5">
-  <p>Your browser is not supported by Scratch Addons.</p>
+  <p>Please update your browser to use Scratch Addons. We recommend exporting your settings before doing so.</p>
   <div id="export-settings" style="display: none">
     <button id="export-btn" class="btn btn-dark dark-btn-white">Export my extension settings</button>
     <button id="export-view-btn" class="btn btn-dark dark-btn-white">View my extension settings</button>

--- a/content/unsupported-browser.html
+++ b/content/unsupported-browser.html
@@ -6,6 +6,9 @@ robots_tag: noindex
 
 <script defer src="/assets/js/unsupported-browser.js"></script>
 
+<!-- Open all links in a new tab, including the navbar and footer links -->
+<base target="_blank"> 
+
 <section id="intro" class="intro-heading">
   <h1 class="mb-3">Unsupported Browser</h1>
   <p class="mb-1">

--- a/static/assets/js/unsupported-browser.js
+++ b/static/assets/js/unsupported-browser.js
@@ -5,6 +5,7 @@ window.parent.postMessage({msgType: "getVersionInfo"}, "*");
 window.addEventListener("message", (e) => {
     if (e.data.versionInfo) {
         document.getElementById("export-settings").style.display = "block"
+        window.parent.postMessage({msgType: "pageTitleInfo", msgContent: document.title}, "*");
     }
 });
 

--- a/static/assets/js/unsupported-browser.js
+++ b/static/assets/js/unsupported-browser.js
@@ -1,5 +1,8 @@
+// Scratch Addons v1.37.0 and greater may iframe this page.
+// If the getVersionInfo message is replied to, we change the UI of the page accordingly.
 window.parent.postMessage({msgType: "getVersionInfo"}, "*");
 
+// To emulate the extension replying, run this in the console:
 // window.self.postMessage({versionInfo: "0.0.1"}, "*")
 
 window.addEventListener("message", (e) => {

--- a/static/assets/js/unsupported-browser.js
+++ b/static/assets/js/unsupported-browser.js
@@ -1,0 +1,16 @@
+window.parent.postMessage({msgType: "getVersionInfo"}, "*");
+
+// window.self.postMessage({versionInfo: "0.0.1"}, "*")
+
+window.addEventListener("message", (e) => {
+    if (e.data.versionInfo) {
+        document.getElementById("export-settings").style.display = "block"
+    }
+});
+
+document.getElementById("export-btn").onclick = () => {
+    window.parent.postMessage({msgType: "exportSettingsAsFile"}, "*");
+}
+document.getElementById("export-view-btn").onclick = () => {
+    window.parent.postMessage({msgType: "openSettingsAsTab"}, "*");
+}

--- a/static/assets/js/unsupported-browser.js
+++ b/static/assets/js/unsupported-browser.js
@@ -8,13 +8,13 @@ window.parent.postMessage({msgType: "getVersionInfo"}, "*");
 window.addEventListener("message", (e) => {
     if (e.data.versionInfo) {
         document.getElementById("export-settings").style.display = "block"
-        window.parent.postMessage({msgType: "pageTitleInfo", msgContent: document.title}, "*");
+        window.parent.postMessage({msgType: "pageTitleInfo", msgContent: document.title}, "*")
     }
 });
 
 document.getElementById("export-btn").onclick = () => {
-    window.parent.postMessage({msgType: "exportSettingsAsFile"}, "*");
+    window.parent.postMessage({msgType: "exportSettingsAsFile"}, "*")
 }
 document.getElementById("export-view-btn").onclick = () => {
-    window.parent.postMessage({msgType: "openSettingsAsTab"}, "*");
+    window.parent.postMessage({msgType: "openSettingsAsTab"}, "*")
 }


### PR DESCRIPTION
Progress for https://github.com/ScratchAddons/ScratchAddons/issues/6876 (see `Add the "export settings" and "view settings as file" buttons to the Unsupported Browser page.`)

![image](https://github.com/ScratchAddons/website-v2/assets/17484114/b969f2b0-3175-449b-8e27-5fa5b879106d)
