### PR TITLE
Docs: update list of languages that accept translators

### DIFF
--- a/content/docs/localization/joining-the-localization-team.md
+++ b/content/docs/localization/joining-the-localization-team.md
@@ -21,7 +21,7 @@ Scratch Addons is available in more than 15 languages thanks to the help of volu
 * You must own an account on [scratch.mit.edu](https://scratch.mit.edu).
 
 {{< admonition info >}}
-**These languages do NOT accept new translators:** Italian, Japanese, Portuguese, Slovenian, Spanish.
+**These languages do NOT accept new translators:** Italian, Spanish.
 <!-- This list of languages is also found below. Remember to update both. -->
 {{< /admonition >}}
 


### PR DESCRIPTION
This updates the list of "languages that do not accept new translators"

- apple502j is not active recently, so I removed Japanese
- For Slovenian, I hope it's fine to remove it from this list. @mxmou you deserve to be helped 😅 
- Portuguese has been behind for a while.