### PR TITLE
MV3 doc updates and  more best practices

### DIFF
--- a/content/docs/develop/getting-started/creating-an-addon.md
+++ b/content/docs/develop/getting-started/creating-an-addon.md
@@ -4,12 +4,12 @@ weight: 3
 aliases:
   - /docs/developing/getting-started/creating-an-addon
 ---
-Required software: text editor, Chrome 121+
+Required software: text editor, Chrome.  
 If possible, disable the Scratch Addons extension you downloaded from the store before proceeding to avoid issues.
 
 
 {{< admonition info >}}
-If you plan to submit the addon you are developing as a pull request to our GitHub repository, please read our [contributing guidelines](https://github.com/ScratchAddons/ScratchAddons/blob/master/.github/CONTRIBUTING.md) first.
+If you plan to submit the addon you are developing as a pull request to our GitHub repository, please read our [contributing guidelines](https://github.com/ScratchAddons/ScratchAddons/blob/master/.github/CONTRIBUTING.md) first. 
 
 In case there is no existing GitHub issue in that repository related to your new addon idea, please [create one](https://github.com/ScratchAddons/ScratchAddons/issues/new/choose). However, if there is already an issue related to your feature idea, we suggest that you leave a comment on it stating your intention to develop the addon. This will enable other contributors to provide feedback on whether the addon could be accepted, or if further discussion is required.
 
@@ -23,25 +23,25 @@ Make sure to read that article to be familiar with the terminology.
 Follow [these instructions](/docs/getting-started/installing/#from-source) to download the source code locally.
 
 ## Step 3: Load the extension into Chrome
-*Note: Chrome is recommended for working on addons. Nevertheless, addons are expected to work on Firefox and Edge.*
-Now that you have the extension in your filesystem, go to `chrome://extensions` and toggle "developer mode".
-Click "load unpacked", then select the folder where Scratch Addons is located. If you're having issues with this, make sure to be selecting the folder where `manifest.json` is located.
-That's it, you loaded the extension! It should look similar to this:
-![image](https://user-images.githubusercontent.com/17484114/91502527-accfd580-e89e-11ea-9e16-7daa2b808379.png)
+*Note: Chrome is recommended for working on addons. Nevertheless, addons are expected to work on Firefox and Edge.*  
+Now that you have the extension in your filesystem, go to `chrome://extensions` and toggle "developer mode".  
+Click "load unpacked", then select the folder where Scratch Addons is located. If you're having issues with this, make sure to be selecting the folder where `manifest.json` is located.  
+That's it, you loaded the extension! It should look similar to this:  
+![image](https://user-images.githubusercontent.com/17484114/91502527-accfd580-e89e-11ea-9e16-7daa2b808379.png)  
 Note: you can safely ignore it says "errors". That's just a warning for an unrecognized manifest key that's required by Firefox.
 
 ## Step 4: What's your addon about?
-Now comes the fun part!
-What will your addon do? Think of a self descriptive addon ID (no spaces or special characters, except hyphens).
+Now comes the fun part!  
+What will your addon do? Think of a self descriptive addon ID (no spaces or special characters, except hyphens).  
 Got it?
 
 ## Step 5: Create the folder for the addon
-Using a file explorer, go to the folder where Scratch Addons resides in your filesystem. Locate the `addons` folder.
+Using a file explorer, go to the folder where Scratch Addons resides in your filesystem. Locate the `addons` folder.  
 Then, create a new folder with your epic addon ID as its name.
 
 ## Step 6: Add an addon manifest
-The addon manifest tells Scratch Addons how your addon works. Make sure to get this right to avoid headaches.
-Inside the folder you just created, create an `addon.json` file.
+The addon manifest tells Scratch Addons how your addon works. Make sure to get this right to avoid headaches.  
+Inside the folder you just created, create an `addon.json` file.  
 This is a base you can use to start coding, make sure to change it in the future:
 ```json
 {
@@ -55,37 +55,37 @@ For more information on what you can declare in the manifest, check [this articl
 
 
 ## Step 7: Tell Scratch Addons what your addon's ID is
-Scratch Addons can't find new folders by itself, so you have to add the name to a special file.
+Scratch Addons can't find new folders by itself, so you have to add the name to a special file.  
 Go to `scratchAddonsFolder/addons/addons.json` and add the ID of your addon to the array.
 
 ## Step 8: Hello world
-Your addon does nothing at the moment, so it's a good time to check if everything we made previously worked.
-Go to `chrome://extensions` and reload Scratch Addons by clicking the refresh symbol on its card.
-Now, right-click the Scratch Addons icon, and click "options".
+Your addon does nothing at the moment, so it's a good time to check if everything we made previously worked.  
+Go to `chrome://extensions` and reload Scratch Addons by clicking the refresh symbol on its card.  
+Now, right-click the Scratch Addons icon, and click "options".  
 You should see your addon on the list! Once you find it, enable it, and set any settings that you may have.
 
 ## Step 9: The fun part, code!
-*Before proceeding, make sure you read the wiki article linked in step 1.*
-
-Here comes the fun part: create your own JS or CSS files!
-Protip: after making any change to your addon, make sure to refresh the Scratch Addons extension like you did in step 8.
-
+*Before proceeding, make sure you read the wiki article linked in step 1.*  
+  
+Here comes the fun part: create your own JS or CSS files!  
+Protip: after making any change to your addon, make sure to refresh the Scratch Addons extension like you did in step 8.  
+  
 Depending on what you want your addon to do, you should now check these wiki pages:
 - [Userscripts](/docs/develop/userscripts)
 - [Userstyles](/docs/develop/userstyles)
 
 ## Step 10: Make your addon customizable
-If you want, you can make your addon customizable!
-Users of your addon will be able to toggle settings, enter numbers, and more!
-To get started, see [how to declare settings in the addon manifest](/docs/reference/addon-manifest/#settings-object).
+If you want, you can make your addon customizable!  
+Users of your addon will be able to toggle settings, enter numbers, and more!  
+To get started, see [how to declare settings in the addon manifest](/docs/reference/addon-manifest/#settings-object).  
 Then, head to the [addon.settings documentation](/docs/reference/addon-api/addon.settings) to learn how to access user choices from userscripts.
 
 ## Step 11: Before publishing your addon
-Now that your addon works, let's make sure we can add it to the addon library.
-Make sure your addon's manifest is suitable, [more info here](/docs/reference/addon-manifest). Keep close attention to the name, description and tags of your addon. Make sure to set `"enabledByDefault"` to `false` or remove it.
-Make sure your addon doesn't break other addons.
+Now that your addon works, let's make sure we can add it to the addon library.  
+Make sure your addon's manifest is suitable, [more info here](/docs/reference/addon-manifest). Keep close attention to the name, description and tags of your addon. Make sure to set `"enabledByDefault"` to `false` or remove it.  
+Make sure your addon doesn't break other addons.  
 Make sure your code is understandable; having unnecessary comments is better than no comments.
 
 ## Step 12: Send a pull request!
-Follow the steps on our [contributing guidelines](https://github.com/ScratchAddons/ScratchAddons/blob/master/.github/CONTRIBUTING.md). Simply put, fork the repo if you haven't already, commit your new addon and send a PR!
+Follow the steps on our [contributing guidelines](https://github.com/ScratchAddons/ScratchAddons/blob/master/.github/CONTRIBUTING.md). Simply put, fork the repo if you haven't already, commit your new addon and send a PR!  
 Keep in mind we might request you to make some changes, however, we will probably accept your addon as long as it's minimally suitable.

--- a/content/docs/develop/getting-started/creating-an-addon.md
+++ b/content/docs/develop/getting-started/creating-an-addon.md
@@ -4,12 +4,12 @@ weight: 3
 aliases:
   - /docs/developing/getting-started/creating-an-addon
 ---
-Required software: text editor, Chrome.  
+Required software: text editor, Chrome 121+
 If possible, disable the Scratch Addons extension you downloaded from the store before proceeding to avoid issues.
 
 
 {{< admonition info >}}
-If you plan to submit the addon you are developing as a pull request to our GitHub repository, please read our [contributing guidelines](https://github.com/ScratchAddons/ScratchAddons/blob/master/.github/CONTRIBUTING.md) first. 
+If you plan to submit the addon you are developing as a pull request to our GitHub repository, please read our [contributing guidelines](https://github.com/ScratchAddons/ScratchAddons/blob/master/.github/CONTRIBUTING.md) first.
 
 In case there is no existing GitHub issue in that repository related to your new addon idea, please [create one](https://github.com/ScratchAddons/ScratchAddons/issues/new/choose). However, if there is already an issue related to your feature idea, we suggest that you leave a comment on it stating your intention to develop the addon. This will enable other contributors to provide feedback on whether the addon could be accepted, or if further discussion is required.
 
@@ -23,25 +23,25 @@ Make sure to read that article to be familiar with the terminology.
 Follow [these instructions](/docs/getting-started/installing/#from-source) to download the source code locally.
 
 ## Step 3: Load the extension into Chrome
-*Note: Chrome is recommended for working on addons. Nevertheless, addons are expected to work on Firefox and Edge.*  
-Now that you have the extension in your filesystem, go to `chrome://extensions` and toggle "developer mode".  
-Click "load unpacked", then select the folder where Scratch Addons is located. If you're having issues with this, make sure to be selecting the folder where `manifest.json` is located.  
-That's it, you loaded the extension! It should look similar to this:  
-![image](https://user-images.githubusercontent.com/17484114/91502527-accfd580-e89e-11ea-9e16-7daa2b808379.png)  
+*Note: Chrome is recommended for working on addons. Nevertheless, addons are expected to work on Firefox and Edge.*
+Now that you have the extension in your filesystem, go to `chrome://extensions` and toggle "developer mode".
+Click "load unpacked", then select the folder where Scratch Addons is located. If you're having issues with this, make sure to be selecting the folder where `manifest.json` is located.
+That's it, you loaded the extension! It should look similar to this:
+![image](https://user-images.githubusercontent.com/17484114/91502527-accfd580-e89e-11ea-9e16-7daa2b808379.png)
 Note: you can safely ignore it says "errors". That's just a warning for an unrecognized manifest key that's required by Firefox.
 
 ## Step 4: What's your addon about?
-Now comes the fun part!  
-What will your addon do? Think of a self descriptive addon ID (no spaces or special characters, except hyphens).  
+Now comes the fun part!
+What will your addon do? Think of a self descriptive addon ID (no spaces or special characters, except hyphens).
 Got it?
 
 ## Step 5: Create the folder for the addon
-Using a file explorer, go to the folder where Scratch Addons resides in your filesystem. Locate the `addons` folder.  
+Using a file explorer, go to the folder where Scratch Addons resides in your filesystem. Locate the `addons` folder.
 Then, create a new folder with your epic addon ID as its name.
 
 ## Step 6: Add an addon manifest
-The addon manifest tells Scratch Addons how your addon works. Make sure to get this right to avoid headaches.  
-Inside the folder you just created, create an `addon.json` file.  
+The addon manifest tells Scratch Addons how your addon works. Make sure to get this right to avoid headaches.
+Inside the folder you just created, create an `addon.json` file.
 This is a base you can use to start coding, make sure to change it in the future:
 ```json
 {
@@ -55,37 +55,37 @@ For more information on what you can declare in the manifest, check [this articl
 
 
 ## Step 7: Tell Scratch Addons what your addon's ID is
-Scratch Addons can't find new folders by itself, so you have to add the name to a special file.  
+Scratch Addons can't find new folders by itself, so you have to add the name to a special file.
 Go to `scratchAddonsFolder/addons/addons.json` and add the ID of your addon to the array.
 
 ## Step 8: Hello world
-Your addon does nothing at the moment, so it's a good time to check if everything we made previously worked.  
-Go to `chrome://extensions` and reload Scratch Addons by clicking the refresh symbol on its card.  
-Now, right-click the Scratch Addons icon, and click "options".  
+Your addon does nothing at the moment, so it's a good time to check if everything we made previously worked.
+Go to `chrome://extensions` and reload Scratch Addons by clicking the refresh symbol on its card.
+Now, right-click the Scratch Addons icon, and click "options".
 You should see your addon on the list! Once you find it, enable it, and set any settings that you may have.
 
 ## Step 9: The fun part, code!
-*Before proceeding, make sure you read the wiki article linked in step 1.*  
-  
-Here comes the fun part: create your own JS or CSS files!  
-Protip: after making any change to your addon, make sure to refresh the Scratch Addons extension like you did in step 8.  
-  
+*Before proceeding, make sure you read the wiki article linked in step 1.*
+
+Here comes the fun part: create your own JS or CSS files!
+Protip: after making any change to your addon, make sure to refresh the Scratch Addons extension like you did in step 8.
+
 Depending on what you want your addon to do, you should now check these wiki pages:
 - [Userscripts](/docs/develop/userscripts)
 - [Userstyles](/docs/develop/userstyles)
 
 ## Step 10: Make your addon customizable
-If you want, you can make your addon customizable!  
-Users of your addon will be able to toggle settings, enter numbers, and more!  
-To get started, see [how to declare settings in the addon manifest](/docs/reference/addon-manifest/#settings-object).  
+If you want, you can make your addon customizable!
+Users of your addon will be able to toggle settings, enter numbers, and more!
+To get started, see [how to declare settings in the addon manifest](/docs/reference/addon-manifest/#settings-object).
 Then, head to the [addon.settings documentation](/docs/reference/addon-api/addon.settings) to learn how to access user choices from userscripts.
 
 ## Step 11: Before publishing your addon
-Now that your addon works, let's make sure we can add it to the addon library.  
-Make sure your addon's manifest is suitable, [more info here](/docs/reference/addon-manifest). Keep close attention to the name, description and tags of your addon. Make sure to set `"enabledByDefault"` to `false` or remove it.  
-Make sure your addon doesn't break other addons.  
+Now that your addon works, let's make sure we can add it to the addon library.
+Make sure your addon's manifest is suitable, [more info here](/docs/reference/addon-manifest). Keep close attention to the name, description and tags of your addon. Make sure to set `"enabledByDefault"` to `false` or remove it.
+Make sure your addon doesn't break other addons.
 Make sure your code is understandable; having unnecessary comments is better than no comments.
 
 ## Step 12: Send a pull request!
-Follow the steps on our [contributing guidelines](https://github.com/ScratchAddons/ScratchAddons/blob/master/.github/CONTRIBUTING.md). Simply put, fork the repo if you haven't already, commit your new addon and send a PR!  
+Follow the steps on our [contributing guidelines](https://github.com/ScratchAddons/ScratchAddons/blob/master/.github/CONTRIBUTING.md). Simply put, fork the repo if you haven't already, commit your new addon and send a PR!
 Keep in mind we might request you to make some changes, however, we will probably accept your addon as long as it's minimally suitable.

--- a/content/docs/develop/userscripts/best-practices.md
+++ b/content/docs/develop/userscripts/best-practices.md
@@ -11,8 +11,8 @@ Follow these best practices when writing or reviewing userscript code.
 
 ### Use addEventListener instead of "onevent"
 
-Avoid setting "onevent" values on HTML elements, such as `onclick`. Instead, use `addEventListener`. This allows multiple addons to register the same event on the same element, without conflicting.  
-It is still valid to use "onevent", but only for elements that were created by the same addon that is registering the event.  
+Avoid setting "onevent" values on HTML elements, such as `onclick`. Instead, use `addEventListener`. This allows multiple addons to register the same event on the same element, without conflicting.
+It is still valid to use "onevent", but only for elements that were created by the same addon that is registering the event.
 In all cases, avoid setting "onevent" HTML attributes, for example `element.setAttribute("onclick", "don't do this")`.
 
 {{< admonition error >}}
@@ -35,7 +35,7 @@ document.querySelector(".remix-button").addEventListener("click", () => {
 
 ### Avoid using innerHTML
 
-Avoid using `innerHTML`. Use `innerText` or `textContent` instead.  
+Avoid using `innerHTML`. Use `innerText` or `textContent` instead.
 Other APIs that can potentially lead to XSS vulnerabilities should be avoided too, such as `insertAdjacentHTML`, `outerHTML`, `document.write()`, etc.
 
 {{< admonition error >}}
@@ -54,9 +54,22 @@ document.querySelector(".sa-remix-button").append(span);
 ```
 {{< /admonition >}}
 
+### Avoid using mousemove
+
+Avoid using `mousemove` and similar DOM events that trigger very often since they are bad for performance, especially when used on the body. Use an alternative event on a child element instead whenever possible.
+
+{{< admonition error >}}
+```js
+// Don't do this:
+body.addEventListener("mousemove", (event) => {
+  // ...
+});
+```
+{{< /admonition >}}
+
 ### Hide elements instead of removing them
 
-Avoid calling `.remove()` on HTML elements, which in extreme cases, can cause the project page to crash.  
+Avoid calling `.remove()` on HTML elements, which in extreme cases, can cause the project page to crash.
 Addons may only use it for elements they themselves created, in specific situations.
 
 {{< admonition error >}}
@@ -78,7 +91,7 @@ document.querySelector(".remix-button").classList.add("sa-remix-button-hidden");
 
 ### Only use waitForElement when necessary
 
-Avoid using the `addon.tab.waitForElement` API if the element is guaranteed to exist. It will still work, and performance will not be heavily impacted, but it might confuse other developers that are reading the code. The usage of waitForElement should usually mean that there is at least 1 scenario where the element doesn't exist at that execution point.  
+Avoid using the `addon.tab.waitForElement` API if the element is guaranteed to exist. It will still work, and performance will not be heavily impacted, but it might confuse other developers that are reading the code. The usage of waitForElement should usually mean that there is at least 1 scenario where the element doesn't exist at that execution point.
 For example, it's not necessary to use waitForElement when searching for forum posts, unless the userscript was declared with `"runAtComplete": false`. In those cases, simply use `document.querySelectorAll()` normally.
 
 ### Use element.closest() instead of abusing parentElement
@@ -112,15 +125,15 @@ reportButton.addEventListener("click", (event) => {
 - Prefer newer APIs, such as `fetch()` over `XMLHttpRequest`.
 - Never use `==` for comparisons. Use `===` instead.
 - When listening to keyboard events, accessing `event.key` is the preferred way to know which key was pressed. In general, you should avoid `event.code` and `event.keyCode`.
-- Use optional chaining if an object can sometimes be `null`.  
+- Use optional chaining if an object can sometimes be `null`.
 For example, `document.querySelector(".remix-button")?.textContent`.
-- Use `for ... of` loops or `.forEach()`.  
+- Use `for ... of` loops or `.forEach()`.
 Avoid C style loops like `for (let i = 0; i < arr.length; i++)`.
 
 ### Only use "let" over "const" if the variable may be reassigned
 
 {{< admonition info >}}
-We usually use `camelCase` to name variables, no matter if they're declared with "let" or "const".  
+We usually use `camelCase` to name variables, no matter if they're declared with "let" or "const".
 For constant strings or numbers, we usually use `SNAKE_CASE`.
 
 Here's an example:
@@ -134,12 +147,12 @@ const DEFAULT_ZOOM = 1.20;
 ```
 {{< /admonition >}}
 
-People reading your code may assume that a variable that was declared through the "let" keyword might be reassigned at some other point of the script. If that's not the case, use the "const" keyword instead.  
+People reading your code may assume that a variable that was declared through the "let" keyword might be reassigned at some other point of the script. If that's not the case, use the "const" keyword instead.
 Remember that in JavaScript, declaring an object or an array as a "const", does not mean its values are frozen. Values in the object can still be changed, even if the variable itself cannot be reassigned.
 
 ### Do not set global variables
 
-Avoid setting properties on the global `window` object, unless you are polluting a global function such as `fetch()`.  
+Avoid setting properties on the global `window` object, unless you are polluting a global function such as `fetch()`.
 If multiple addons need to share information or functions between each other, create a JS module file and import it from both userscripts.
 
 {{< admonition error >}}
@@ -157,8 +170,8 @@ You may move functions to separate JS module files (which aren't declared as use
 
 ### Do not unpollute functions
 
-Multiple addons might want to pollute the same function, such as Scratch VM methods, `XMLHttpRequest`, `fetch()` or `FileReader()`.  
-In those cases, one of the userscripts will be polluting the real function, while the others will be polluting functions which were already polluted themselves. If, for example, the first userscript that polluted decides to unpollute (for example, by doing `window.fetch = realFetch`), then all other functions in the "pollution chain" are also lost, which is unexpected.  
+Multiple addons might want to pollute the same function, such as Scratch VM methods, `XMLHttpRequest`, `fetch()` or `FileReader()`.
+In those cases, one of the userscripts will be polluting the real function, while the others will be polluting functions which were already polluted themselves. If, for example, the first userscript that polluted decides to unpollute (for example, by doing `window.fetch = realFetch`), then all other functions in the "pollution chain" are also lost, which is unexpected.
 For this reason, functions should not be unpolluted. Instead, pass the arguments to the original function.
 
 {{< admonition error >}}
@@ -185,3 +198,24 @@ const newDeleteSprite = function (...args) {
 };
 ```
 {{< /admonition >}}
+
+## Internationalization
+
+### Use addon.tab.scratchMessage()
+
+If a string has already been translated by Scratch use [addon.tab.scratchMessage](/docs/reference/addon-api/addon.tab/#addontabscratchmessage) instead of adding a new message.
+
+{{< admonition error >}}
+```js
+// Don't do this:
+doneButton.innerText = msg("done");
+```
+{{< /admonition >}}
+
+{{< admonition success >}}
+```js
+// Do this instead:
+doneButton.innerText = addon.tab.scratchMessage("general.done");
+```
+{{< /admonition >}}
+

--- a/content/docs/develop/userscripts/best-practices.md
+++ b/content/docs/develop/userscripts/best-practices.md
@@ -11,8 +11,8 @@ Follow these best practices when writing or reviewing userscript code.
 
 ### Use addEventListener instead of "onevent"
 
-Avoid setting "onevent" values on HTML elements, such as `onclick`. Instead, use `addEventListener`. This allows multiple addons to register the same event on the same element, without conflicting.
-It is still valid to use "onevent", but only for elements that were created by the same addon that is registering the event.
+Avoid setting "onevent" values on HTML elements, such as `onclick`. Instead, use `addEventListener`. This allows multiple addons to register the same event on the same element, without conflicting.  
+It is still valid to use "onevent", but only for elements that were created by the same addon that is registering the event.  
 In all cases, avoid setting "onevent" HTML attributes, for example `element.setAttribute("onclick", "don't do this")`.
 
 {{< admonition error >}}
@@ -35,7 +35,7 @@ document.querySelector(".remix-button").addEventListener("click", () => {
 
 ### Avoid using innerHTML
 
-Avoid using `innerHTML`. Use `innerText` or `textContent` instead.
+Avoid using `innerHTML`. Use `innerText` or `textContent` instead.  
 Other APIs that can potentially lead to XSS vulnerabilities should be avoided too, such as `insertAdjacentHTML`, `outerHTML`, `document.write()`, etc.
 
 {{< admonition error >}}
@@ -54,22 +54,9 @@ document.querySelector(".sa-remix-button").append(span);
 ```
 {{< /admonition >}}
 
-### Avoid using mousemove
-
-Avoid using `mousemove` and similar DOM events that trigger very often since they are bad for performance, especially when used on the body. Use an alternative event on a child element instead whenever possible.
-
-{{< admonition error >}}
-```js
-// Don't do this:
-body.addEventListener("mousemove", (event) => {
-  // ...
-});
-```
-{{< /admonition >}}
-
 ### Hide elements instead of removing them
 
-Avoid calling `.remove()` on HTML elements, which in extreme cases, can cause the project page to crash.
+Avoid calling `.remove()` on HTML elements, which in extreme cases, can cause the project page to crash.  
 Addons may only use it for elements they themselves created, in specific situations.
 
 {{< admonition error >}}
@@ -91,7 +78,7 @@ document.querySelector(".remix-button").classList.add("sa-remix-button-hidden");
 
 ### Only use waitForElement when necessary
 
-Avoid using the `addon.tab.waitForElement` API if the element is guaranteed to exist. It will still work, and performance will not be heavily impacted, but it might confuse other developers that are reading the code. The usage of waitForElement should usually mean that there is at least 1 scenario where the element doesn't exist at that execution point.
+Avoid using the `addon.tab.waitForElement` API if the element is guaranteed to exist. It will still work, and performance will not be heavily impacted, but it might confuse other developers that are reading the code. The usage of waitForElement should usually mean that there is at least 1 scenario where the element doesn't exist at that execution point.  
 For example, it's not necessary to use waitForElement when searching for forum posts, unless the userscript was declared with `"runAtComplete": false`. In those cases, simply use `document.querySelectorAll()` normally.
 
 ### Use element.closest() instead of abusing parentElement
@@ -125,15 +112,15 @@ reportButton.addEventListener("click", (event) => {
 - Prefer newer APIs, such as `fetch()` over `XMLHttpRequest`.
 - Never use `==` for comparisons. Use `===` instead.
 - When listening to keyboard events, accessing `event.key` is the preferred way to know which key was pressed. In general, you should avoid `event.code` and `event.keyCode`.
-- Use optional chaining if an object can sometimes be `null`.
+- Use optional chaining if an object can sometimes be `null`.  
 For example, `document.querySelector(".remix-button")?.textContent`.
-- Use `for ... of` loops or `.forEach()`.
+- Use `for ... of` loops or `.forEach()`.  
 Avoid C style loops like `for (let i = 0; i < arr.length; i++)`.
 
 ### Only use "let" over "const" if the variable may be reassigned
 
 {{< admonition info >}}
-We usually use `camelCase` to name variables, no matter if they're declared with "let" or "const".
+We usually use `camelCase` to name variables, no matter if they're declared with "let" or "const".  
 For constant strings or numbers, we usually use `SNAKE_CASE`.
 
 Here's an example:
@@ -147,12 +134,12 @@ const DEFAULT_ZOOM = 1.20;
 ```
 {{< /admonition >}}
 
-People reading your code may assume that a variable that was declared through the "let" keyword might be reassigned at some other point of the script. If that's not the case, use the "const" keyword instead.
+People reading your code may assume that a variable that was declared through the "let" keyword might be reassigned at some other point of the script. If that's not the case, use the "const" keyword instead.  
 Remember that in JavaScript, declaring an object or an array as a "const", does not mean its values are frozen. Values in the object can still be changed, even if the variable itself cannot be reassigned.
 
 ### Do not set global variables
 
-Avoid setting properties on the global `window` object, unless you are polluting a global function such as `fetch()`.
+Avoid setting properties on the global `window` object, unless you are polluting a global function such as `fetch()`.  
 If multiple addons need to share information or functions between each other, create a JS module file and import it from both userscripts.
 
 {{< admonition error >}}
@@ -170,8 +157,8 @@ You may move functions to separate JS module files (which aren't declared as use
 
 ### Do not unpollute functions
 
-Multiple addons might want to pollute the same function, such as Scratch VM methods, `XMLHttpRequest`, `fetch()` or `FileReader()`.
-In those cases, one of the userscripts will be polluting the real function, while the others will be polluting functions which were already polluted themselves. If, for example, the first userscript that polluted decides to unpollute (for example, by doing `window.fetch = realFetch`), then all other functions in the "pollution chain" are also lost, which is unexpected.
+Multiple addons might want to pollute the same function, such as Scratch VM methods, `XMLHttpRequest`, `fetch()` or `FileReader()`.  
+In those cases, one of the userscripts will be polluting the real function, while the others will be polluting functions which were already polluted themselves. If, for example, the first userscript that polluted decides to unpollute (for example, by doing `window.fetch = realFetch`), then all other functions in the "pollution chain" are also lost, which is unexpected.  
 For this reason, functions should not be unpolluted. Instead, pass the arguments to the original function.
 
 {{< admonition error >}}
@@ -198,24 +185,3 @@ const newDeleteSprite = function (...args) {
 };
 ```
 {{< /admonition >}}
-
-## Internationalization
-
-### Use addon.tab.scratchMessage()
-
-If a string has already been translated by Scratch use [addon.tab.scratchMessage](/docs/reference/addon-api/addon.tab/#addontabscratchmessage) instead of adding a new message.
-
-{{< admonition error >}}
-```js
-// Don't do this:
-doneButton.innerText = msg("done");
-```
-{{< /admonition >}}
-
-{{< admonition success >}}
-```js
-// Do this instead:
-doneButton.innerText = addon.tab.scratchMessage("general.done");
-```
-{{< /admonition >}}
-

--- a/content/docs/develop/userscripts/best-practices.md
+++ b/content/docs/develop/userscripts/best-practices.md
@@ -54,6 +54,19 @@ document.querySelector(".sa-remix-button").append(span);
 ```
 {{< /admonition >}}
 
+### Avoid using mousemove
+
+Avoid using `mousemove` and similar DOM events that trigger very often since they are bad for performance, especially when used on the body. Use an alternative event on a child element instead whenever possible.
+
+{{< admonition error >}}
+```js
+// Don't do this:
+body.addEventListener("mousemove", (event) => {
+  // ...
+});
+```
+{{< /admonition >}}
+
 ### Hide elements instead of removing them
 
 Avoid calling `.remove()` on HTML elements, which in extreme cases, can cause the project page to crash.  
@@ -183,5 +196,25 @@ const newDeleteSprite = function (...args) {
   if (addon.self.disabled) return oldDeleteSprite.apply(this, args);
   // ...
 };
+```
+{{< /admonition >}}
+
+## Internationalization
+
+### Use addon.tab.scratchMessage()
+
+If a string has already been translated by Scratch use [addon.tab.scratchMessage](/docs/reference/addon-api/addon.tab/#addontabscratchmessage) instead of adding a new message.
+
+{{< admonition error >}}
+```js
+// Don't do this:
+doneButton.innerText = msg("done");
+```
+{{< /admonition >}}
+
+{{< admonition success >}}
+```js
+// Do this instead:
+doneButton.innerText = addon.tab.scratchMessage("general.done");
 ```
 {{< /admonition >}}

--- a/content/docs/develop/userscripts/debugging-userscripts.md
+++ b/content/docs/develop/userscripts/debugging-userscripts.md
@@ -13,7 +13,14 @@ It's not necessary to reload the extension by going to `chrome://extensions` whe
 
 ### Use the addon.* API from the console
 
-The `addon` object is accessible within the browser console through the `__addon` global variable when at least one addon is running.
+For development, you may choose to expose the `addon` object as a global variable, so that it can be accessed within the browser console.
+
+```js
+export default async function ({ addon, console }) {
+  window.addon = addon;
+  // ...
+}
+```
 
 ### Set breakpoints with the "debugger" keyword
 
@@ -32,7 +39,7 @@ Enter the addon ID on the "filter" console search bar to only view logs and warn
 
 #### The DOM is destroyed after going inside or outside the editor
 
-Scratch creates all HTML elements each time the user clicks "see inside" or "see project page", and destroys the old ones.
+Scratch creates all HTML elements each time the user clicks "see inside" or "see project page", and destroys the old ones.  
 This can usually be fixed by using `addon.tab.waitForElement` or the `urlChange` event.
 
 #### The Scratch editor language can be changed without a reload
@@ -49,7 +56,7 @@ Unlike the Scratch website, the Scratch editor will not reload when changing the
 
 #### scratch-www pages don't reload after logging in
 
-Unlike scratchr2 pages, scratch-www pages do not force a page reload after logging in. For example, if you go to a project page while being logged out, then log in, the page will not reload. This also affects studios, the messages page, etc.
+Unlike scratchr2 pages, scratch-www pages do not force a page reload after logging in. For example, if you go to a project page while being logged out, then log in, the page will not reload. This also affects studios, the messages page, etc.  
 In contrast, all Scratch pages reload after logging out.
 
 #### Project pages never return 404s

--- a/content/docs/develop/userscripts/debugging-userscripts.md
+++ b/content/docs/develop/userscripts/debugging-userscripts.md
@@ -13,14 +13,7 @@ It's not necessary to reload the extension by going to `chrome://extensions` whe
 
 ### Use the addon.* API from the console
 
-For development, you may choose to expose the `addon` object as a global variable, so that it can be accessed within the browser console.
-
-```js
-export default async function ({ addon, console }) {
-  window.addon = addon;
-  // ...
-}
-```
+The `addon` object is accessible within the browser console through the `__addon` global variable when at least one addon is running.
 
 ### Set breakpoints with the "debugger" keyword
 

--- a/content/docs/develop/userscripts/debugging-userscripts.md
+++ b/content/docs/develop/userscripts/debugging-userscripts.md
@@ -13,14 +13,7 @@ It's not necessary to reload the extension by going to `chrome://extensions` whe
 
 ### Use the addon.* API from the console
 
-For development, you may choose to expose the `addon` object as a global variable, so that it can be accessed within the browser console.
-
-```js
-export default async function ({ addon, console }) {
-  window.addon = addon;
-  // ...
-}
-```
+The `addon` object is accessible within the browser console through the `__addon` global variable when at least one addon is running.
 
 ### Set breakpoints with the "debugger" keyword
 
@@ -39,7 +32,7 @@ Enter the addon ID on the "filter" console search bar to only view logs and warn
 
 #### The DOM is destroyed after going inside or outside the editor
 
-Scratch creates all HTML elements each time the user clicks "see inside" or "see project page", and destroys the old ones.  
+Scratch creates all HTML elements each time the user clicks "see inside" or "see project page", and destroys the old ones.
 This can usually be fixed by using `addon.tab.waitForElement` or the `urlChange` event.
 
 #### The Scratch editor language can be changed without a reload
@@ -56,7 +49,7 @@ Unlike the Scratch website, the Scratch editor will not reload when changing the
 
 #### scratch-www pages don't reload after logging in
 
-Unlike scratchr2 pages, scratch-www pages do not force a page reload after logging in. For example, if you go to a project page while being logged out, then log in, the page will not reload. This also affects studios, the messages page, etc.  
+Unlike scratchr2 pages, scratch-www pages do not force a page reload after logging in. For example, if you go to a project page while being logged out, then log in, the page will not reload. This also affects studios, the messages page, etc.
 In contrast, all Scratch pages reload after logging out.
 
 #### Project pages never return 404s

--- a/content/docs/reference/addon-api/addon.self.md
+++ b/content/docs/reference/addon-api/addon.self.md
@@ -19,15 +19,15 @@ Allows addons to get information about themselves or the browser.
 With `addon.self.dir`, we can get the URL to an image inside the addon's directory.
 ```js
   const img = document.createElement("img");
-  img.src = addon.self.dir + "/image.svg";
+  img.src = addon.self.dir + "/image.svg"; 
   // Will be something like `chrome-extension://aeepldbjfoihffgcaejikpoeppffnlbd/addons/addon-id/image.svg`
   document.body.appendChild(img);
 ```
 
 ### Using `addon.self.disabled` and events (`dynamicDisable`)
 We use the `disabled` and `reenabled` events to hide the image when the addon is disabled, without
-requiring the user to refresh the page.
-We also use `addon.self.disabled` inside an event listener to avoid running code while the addon is disabled.
+requiring the user to refresh the page.  
+We also use `addon.self.disabled` inside an event listener to avoid running code while the addon is disabled.  
 This example requires `{"dynamicDisable": true}` in the manifest.
 ```js
   addon.self.addEventListener("disabled", () => img.style.visibility = "visible");
@@ -48,11 +48,11 @@ This example requires `{"dynamicDisable": true}` in the manifest.
   </tr>
   <tr>
     <td>Nullable</td>
-    <td>No</td>
+    <td>No</td> 
   </tr>
 </table>
 
-The addon ID for this addon.
+The addon ID for this addon.  
 The addon ID is the name of the directory inside `/addons` that identifies the addon.
 
 ### `addon.self.dir`
@@ -63,12 +63,26 @@ The addon ID is the name of the directory inside `/addons` that identifies the a
   </tr>
   <tr>
     <td>Nullable</td>
-    <td>No</td>
+    <td>No</td> 
   </tr>
 </table>
 
-Path to the addon's directory, without trailing slash.
+Path to the addon's directory, without trailing slash.  
 Should be used instead of hardcoding URLs. Locally, using a hardcoded URL like `chrome-extension://aeepldbjfoihffgcaejikpoeppffnlbd/addons/full-signature/happen.js` might appear to work properly, but the extension ID can change and it will not work in Firefox.
+
+### `addon.self.lib`
+<table>
+  <tr>
+    <td>Type</td>
+    <td><code>String</code></td>
+  </tr>
+  <tr>
+    <td>Nullable</td>
+    <td>No</td> 
+  </tr>
+</table>
+
+Path to the `/libraries` directory, without trailing slash.
 
 ### `addon.self.browser`
 <table>
@@ -78,7 +92,7 @@ Should be used instead of hardcoding URLs. Locally, using a hardcoded URL like `
   </tr>
   <tr>
     <td>Nullable</td>
-    <td>No</td>
+    <td>No</td> 
   </tr>
 </table>
 
@@ -92,11 +106,11 @@ The browser Scratch Addons is running on.
   </tr>
   <tr>
     <td>Nullable</td>
-    <td>No</td>
+    <td>No</td> 
   </tr>
 </table>
 
-Whether the addon is currently disabled or not.
+Whether the addon is currently disabled or not.  
 Useful for returning early in event listeners for addons that support `dynamicDisable`.
 
 ### `addon.self.enabledLate`
@@ -107,12 +121,12 @@ Useful for returning early in event listeners for addons that support `dynamicDi
   </tr>
   <tr>
     <td>Nullable</td>
-    <td>No</td>
+    <td>No</td> 
   </tr>
 </table>
 
-Whether the running userscript was injected dynamically in response to the user enabling the addon.
-Can only be `true` if the addon supports dynamicEnable.
+Whether the running userscript was injected dynamically in response to the user enabling the addon.  
+Can only be `true` if the addon supports dynamicEnable.  
 If the addon was enabled when the page loaded, then was disabled and reenabled, this will still be `false`.
 In that case, the `reenabled` event will fire.
 
@@ -144,9 +158,9 @@ Gets a list of addon IDs enabled, optionally filtered using a [tag](/docs/refere
 
 ## Events
 ### `disabled`
-Fires when the addon gets disabled.
+Fires when the addon gets disabled.  
 Requires the `dynamicDisable` manifest property.
 
 ### `reenabled`
-Fires when the addon gets reenabled, after being disabled.
+Fires when the addon gets reenabled, after being disabled.  
 <!-- Requires the `dynamicDisable` manifest property. -->

--- a/content/docs/reference/addon-api/addon.self.md
+++ b/content/docs/reference/addon-api/addon.self.md
@@ -70,20 +70,6 @@ The addon ID is the name of the directory inside `/addons` that identifies the a
 Path to the addon's directory, without trailing slash.  
 Should be used instead of hardcoding URLs. Locally, using a hardcoded URL like `chrome-extension://aeepldbjfoihffgcaejikpoeppffnlbd/addons/full-signature/happen.js` might appear to work properly, but the extension ID can change and it will not work in Firefox.
 
-### `addon.self.lib`
-<table>
-  <tr>
-    <td>Type</td>
-    <td><code>String</code></td>
-  </tr>
-  <tr>
-    <td>Nullable</td>
-    <td>No</td> 
-  </tr>
-</table>
-
-Path to the `/libraries` directory, without trailing slash.
-
 ### `addon.self.browser`
 <table>
   <tr>

--- a/content/docs/reference/addon-api/addon.self.md
+++ b/content/docs/reference/addon-api/addon.self.md
@@ -19,15 +19,15 @@ Allows addons to get information about themselves or the browser.
 With `addon.self.dir`, we can get the URL to an image inside the addon's directory.
 ```js
   const img = document.createElement("img");
-  img.src = addon.self.dir + "/image.svg"; 
+  img.src = addon.self.dir + "/image.svg";
   // Will be something like `chrome-extension://aeepldbjfoihffgcaejikpoeppffnlbd/addons/addon-id/image.svg`
   document.body.appendChild(img);
 ```
 
 ### Using `addon.self.disabled` and events (`dynamicDisable`)
 We use the `disabled` and `reenabled` events to hide the image when the addon is disabled, without
-requiring the user to refresh the page.  
-We also use `addon.self.disabled` inside an event listener to avoid running code while the addon is disabled.  
+requiring the user to refresh the page.
+We also use `addon.self.disabled` inside an event listener to avoid running code while the addon is disabled.
 This example requires `{"dynamicDisable": true}` in the manifest.
 ```js
   addon.self.addEventListener("disabled", () => img.style.visibility = "visible");
@@ -48,11 +48,11 @@ This example requires `{"dynamicDisable": true}` in the manifest.
   </tr>
   <tr>
     <td>Nullable</td>
-    <td>No</td> 
+    <td>No</td>
   </tr>
 </table>
 
-The addon ID for this addon.  
+The addon ID for this addon.
 The addon ID is the name of the directory inside `/addons` that identifies the addon.
 
 ### `addon.self.dir`
@@ -63,26 +63,12 @@ The addon ID is the name of the directory inside `/addons` that identifies the a
   </tr>
   <tr>
     <td>Nullable</td>
-    <td>No</td> 
+    <td>No</td>
   </tr>
 </table>
 
-Path to the addon's directory, without trailing slash.  
+Path to the addon's directory, without trailing slash.
 Should be used instead of hardcoding URLs. Locally, using a hardcoded URL like `chrome-extension://aeepldbjfoihffgcaejikpoeppffnlbd/addons/full-signature/happen.js` might appear to work properly, but the extension ID can change and it will not work in Firefox.
-
-### `addon.self.lib`
-<table>
-  <tr>
-    <td>Type</td>
-    <td><code>String</code></td>
-  </tr>
-  <tr>
-    <td>Nullable</td>
-    <td>No</td> 
-  </tr>
-</table>
-
-Path to the `/libraries` directory, without trailing slash.
 
 ### `addon.self.browser`
 <table>
@@ -92,7 +78,7 @@ Path to the `/libraries` directory, without trailing slash.
   </tr>
   <tr>
     <td>Nullable</td>
-    <td>No</td> 
+    <td>No</td>
   </tr>
 </table>
 
@@ -106,11 +92,11 @@ The browser Scratch Addons is running on.
   </tr>
   <tr>
     <td>Nullable</td>
-    <td>No</td> 
+    <td>No</td>
   </tr>
 </table>
 
-Whether the addon is currently disabled or not.  
+Whether the addon is currently disabled or not.
 Useful for returning early in event listeners for addons that support `dynamicDisable`.
 
 ### `addon.self.enabledLate`
@@ -121,12 +107,12 @@ Useful for returning early in event listeners for addons that support `dynamicDi
   </tr>
   <tr>
     <td>Nullable</td>
-    <td>No</td> 
+    <td>No</td>
   </tr>
 </table>
 
-Whether the running userscript was injected dynamically in response to the user enabling the addon.  
-Can only be `true` if the addon supports dynamicEnable.  
+Whether the running userscript was injected dynamically in response to the user enabling the addon.
+Can only be `true` if the addon supports dynamicEnable.
 If the addon was enabled when the page loaded, then was disabled and reenabled, this will still be `false`.
 In that case, the `reenabled` event will fire.
 
@@ -158,9 +144,9 @@ Gets a list of addon IDs enabled, optionally filtered using a [tag](/docs/refere
 
 ## Events
 ### `disabled`
-Fires when the addon gets disabled.  
+Fires when the addon gets disabled.
 Requires the `dynamicDisable` manifest property.
 
 ### `reenabled`
-Fires when the addon gets reenabled, after being disabled.  
+Fires when the addon gets reenabled, after being disabled.
 <!-- Requires the `dynamicDisable` manifest property. -->

--- a/content/docs/reference/addon-api/addon.tab/_index.md
+++ b/content/docs/reference/addon-api/addon.tab/_index.md
@@ -16,7 +16,7 @@ Allows addon userscripts to get information about the tab they're currently runn
 
 ## Examples
 ### Using `addon.tab.waitForElement`
-We can use `addon.tab.waitForElement` with `{"markAsSeen": true}` inside a `while(true)` loop to store the IDs of all comments in the page.
+We can use `addon.tab.waitForElement` with `{"markAsSeen": true}` inside a `while(true)` loop to store the IDs of all comments in the page.  
 Using `addon.tab.waitForElement`, we don't need to have code that waits until comments have loaded. This way, we also store the IDs of newly posted comments and new loaded comments when the user clicks "load more comments".
 ```js
 const commentIds = [];
@@ -29,8 +29,8 @@ while (true) {
 ```
 
 ### Using `addon.tab.displayNoneWhileDisabled` (`dynamicDisable`)
-We use `addon.tab.displayNoneWhileDisabled` to hide an image when the addon gets disabled.
-We create a button to hide the image when clicked, and the image succesfully gets hidden, even if the addon is enabled.
+We use `addon.tab.displayNoneWhileDisabled` to hide an image when the addon gets disabled.  
+We create a button to hide the image when clicked, and the image succesfully gets hidden, even if the addon is enabled.  
 We also set the `display` CSS property of the image to `flex` when visible, even though that is not the default value for images.
 ```js
   /* userscript.js */
@@ -52,7 +52,7 @@ We also set the `display` CSS property of the image to `flex` when visible, even
   display: flex;
 }
 .sa-example-img-hide {
-  /* We want to hide the image if the button was clicked,
+  /* We want to hide the image if the button was clicked, 
   even if the addon is enabled */
   display: none !important;
 }
@@ -80,13 +80,13 @@ Allows addons to get and modify Redux state, which is useful for addons that mod
   </tr>
   <tr>
     <td>Nullable</td>
-    <td>Yes</td>
+    <td>Yes</td> 
   </tr>
 </table>
 
-The Scratch client for the current tab (`scratch-www` or `scratchr2`).
-The Scratch community website has 2 working clients used throughout the site.
-`scratch-www` is React/Redux based and client side rendered. This client is the one used in the homepage.
+The Scratch client for the current tab (`scratch-www` or `scratchr2`).  
+The Scratch community website has 2 working clients used throughout the site.  
+`scratch-www` is React/Redux based and client side rendered. This client is the one used in the homepage.  
 `scratchr2` is Django/jQuery/Backbone.js based and mostly server side rendered. This client is the one used in profile pages.
 
 ### `addon.tab.editorMode`
@@ -97,11 +97,11 @@ The Scratch community website has 2 working clients used throughout the site.
   </tr>
   <tr>
     <td>Nullable</td>
-    <td>Yes</td>
+    <td>Yes</td> 
   </tr>
 </table>
 
-The current viewing mode for the project (`projectpage`, `editor`, `fullscreen` or `embed`).
+The current viewing mode for the project (`projectpage`, `editor`, `fullscreen` or `embed`).  
 Will be `null` if the current tab is not a project.
 
 ### `addon.tab.direction`
@@ -112,7 +112,7 @@ Will be `null` if the current tab is not a project.
   </tr>
   <tr>
     <td>Nullable</td>
-    <td>No</td>
+    <td>No</td> 
   </tr>
 </table>
 
@@ -186,9 +186,9 @@ The writing direction for the language of the Scratch website.
   </tr>
 </table>
 
-Waits until an element exists, then returns the element.
-Internally, a `MutationObserver` that reacts to any DOM tree change is used. This observer does not react to attribute-only DOM updates.
-Option `markAsSeen` should be set to true if you're using this method inside a `while(true)` loop.
+Waits until an element exists, then returns the element.  
+Internally, a `MutationObserver` that reacts to any DOM tree change is used. This observer does not react to attribute-only DOM updates.  
+Option `markAsSeen` should be set to true if you're using this method inside a `while(true)` loop.  
 Options `condition`, `reduxCondition` and `reduxEvents` should be used as optimizations, in order to avoid multiple calls to `document.querySelector` when it's guaranteed the element will not exist yet.
 
 ### `addon.tab.displayNoneWhileDisabled`
@@ -230,8 +230,8 @@ Options `condition`, `reduxCondition` and `reduxEvents` should be used as optimi
   </tr>
 </table>
 
-Hides the given element with `display: none` when the addon is disabled, until it is reenabled.
-If the intended `display` CSS property value for the provided element when visible is not the default value for the type of provided element (for example, `block` for `div`s and `inline` for `span`s), you should provide that value inside the options parameter.
+Hides the given element with `display: none` when the addon is disabled, until it is reenabled.  
+If the intended `display` CSS property value for the provided element when visible is not the default value for the type of provided element (for example, `block` for `div`s and `inline` for `span`s), you should provide that value inside the options parameter.  
 If you want to manually hide the element in situations where the addon is enabled, you should use a dedicated class name for that, instead of manually setting `el.style.display = "none";`. Use a class name selector in a userstyle to set `display: none !important;` on the element.
 
 ### `addon.tab.copyImage`
@@ -266,8 +266,8 @@ If you want to manually hide the element in situations where the addon is enable
     <td>Image could not be copied.</td>
 </table>
 
-Copies a PNG image to the clipboard.
-Only run this in response of the user explicitly pressing Ctrl+C.
+Copies a PNG image to the clipboard.  
+Only run this in response of the user explicitly pressing Ctrl+C.  
 Internally uses `browser.clipboard.setImageData` in Firefox and `navigator.clipboard.write` in Chrome and Edge.
 
 ### `addon.tab.scratchClass`
@@ -339,9 +339,9 @@ Gets the hashed class name for a Scratch stylesheet class name.
   </tr>
 </table>
 
-Gets Scratch translation from the current Scratch tab.
-Note that these are Scratch locales, not Scratch Addons locales.
-If the message isn't found, `""` is returned and a warning is logged in the console.
+Gets Scratch translation from the current Scratch tab.  
+Note that these are Scratch locales, not Scratch Addons locales.  
+If the message isn't found, `""` is returned and a warning is logged in the console.  
 Internally uses `window.django.gettext` or `window._messages`.
 
 ### [`addon.tab.appendToSharedSpace`](addon.tab.appendtosharedspace)
@@ -973,7 +973,7 @@ Removes a block that was previously added to the Debugger category in the block 
   </tr>
 </table>
 
-Runs the specified script file relative to the extension's root (e.g. `chrome-extension://aeepldbjfoihffgcaejikpoeppffnlbd/`) in a `<script>` tag.
+Runs the specified script file.
 
 ### `addon.tab.loadWorker`
 <table>
@@ -1020,6 +1020,6 @@ Loads the specified Web Worker.
   </tr>
 </table>
 
-Fires when Scratch dynamically changes the URL of the page.
-This happens when going inside/outside the editor, or switching tabs in scratch-www studio pages.
+Fires when Scratch dynamically changes the URL of the page.  
+This happens when going inside/outside the editor, or switching tabs in scratch-www studio pages.  
 This will not fire if `location.hash` changed.

--- a/content/docs/reference/addon-api/addon.tab/_index.md
+++ b/content/docs/reference/addon-api/addon.tab/_index.md
@@ -16,7 +16,7 @@ Allows addon userscripts to get information about the tab they're currently runn
 
 ## Examples
 ### Using `addon.tab.waitForElement`
-We can use `addon.tab.waitForElement` with `{"markAsSeen": true}` inside a `while(true)` loop to store the IDs of all comments in the page.  
+We can use `addon.tab.waitForElement` with `{"markAsSeen": true}` inside a `while(true)` loop to store the IDs of all comments in the page.
 Using `addon.tab.waitForElement`, we don't need to have code that waits until comments have loaded. This way, we also store the IDs of newly posted comments and new loaded comments when the user clicks "load more comments".
 ```js
 const commentIds = [];
@@ -29,8 +29,8 @@ while (true) {
 ```
 
 ### Using `addon.tab.displayNoneWhileDisabled` (`dynamicDisable`)
-We use `addon.tab.displayNoneWhileDisabled` to hide an image when the addon gets disabled.  
-We create a button to hide the image when clicked, and the image succesfully gets hidden, even if the addon is enabled.  
+We use `addon.tab.displayNoneWhileDisabled` to hide an image when the addon gets disabled.
+We create a button to hide the image when clicked, and the image succesfully gets hidden, even if the addon is enabled.
 We also set the `display` CSS property of the image to `flex` when visible, even though that is not the default value for images.
 ```js
   /* userscript.js */
@@ -52,7 +52,7 @@ We also set the `display` CSS property of the image to `flex` when visible, even
   display: flex;
 }
 .sa-example-img-hide {
-  /* We want to hide the image if the button was clicked, 
+  /* We want to hide the image if the button was clicked,
   even if the addon is enabled */
   display: none !important;
 }
@@ -80,13 +80,13 @@ Allows addons to get and modify Redux state, which is useful for addons that mod
   </tr>
   <tr>
     <td>Nullable</td>
-    <td>Yes</td> 
+    <td>Yes</td>
   </tr>
 </table>
 
-The Scratch client for the current tab (`scratch-www` or `scratchr2`).  
-The Scratch community website has 2 working clients used throughout the site.  
-`scratch-www` is React/Redux based and client side rendered. This client is the one used in the homepage.  
+The Scratch client for the current tab (`scratch-www` or `scratchr2`).
+The Scratch community website has 2 working clients used throughout the site.
+`scratch-www` is React/Redux based and client side rendered. This client is the one used in the homepage.
 `scratchr2` is Django/jQuery/Backbone.js based and mostly server side rendered. This client is the one used in profile pages.
 
 ### `addon.tab.editorMode`
@@ -97,11 +97,11 @@ The Scratch community website has 2 working clients used throughout the site.
   </tr>
   <tr>
     <td>Nullable</td>
-    <td>Yes</td> 
+    <td>Yes</td>
   </tr>
 </table>
 
-The current viewing mode for the project (`projectpage`, `editor`, `fullscreen` or `embed`).  
+The current viewing mode for the project (`projectpage`, `editor`, `fullscreen` or `embed`).
 Will be `null` if the current tab is not a project.
 
 ### `addon.tab.direction`
@@ -112,7 +112,7 @@ Will be `null` if the current tab is not a project.
   </tr>
   <tr>
     <td>Nullable</td>
-    <td>No</td> 
+    <td>No</td>
   </tr>
 </table>
 
@@ -186,9 +186,9 @@ The writing direction for the language of the Scratch website.
   </tr>
 </table>
 
-Waits until an element exists, then returns the element.  
-Internally, a `MutationObserver` that reacts to any DOM tree change is used. This observer does not react to attribute-only DOM updates.  
-Option `markAsSeen` should be set to true if you're using this method inside a `while(true)` loop.  
+Waits until an element exists, then returns the element.
+Internally, a `MutationObserver` that reacts to any DOM tree change is used. This observer does not react to attribute-only DOM updates.
+Option `markAsSeen` should be set to true if you're using this method inside a `while(true)` loop.
 Options `condition`, `reduxCondition` and `reduxEvents` should be used as optimizations, in order to avoid multiple calls to `document.querySelector` when it's guaranteed the element will not exist yet.
 
 ### `addon.tab.displayNoneWhileDisabled`
@@ -230,8 +230,8 @@ Options `condition`, `reduxCondition` and `reduxEvents` should be used as optimi
   </tr>
 </table>
 
-Hides the given element with `display: none` when the addon is disabled, until it is reenabled.  
-If the intended `display` CSS property value for the provided element when visible is not the default value for the type of provided element (for example, `block` for `div`s and `inline` for `span`s), you should provide that value inside the options parameter.  
+Hides the given element with `display: none` when the addon is disabled, until it is reenabled.
+If the intended `display` CSS property value for the provided element when visible is not the default value for the type of provided element (for example, `block` for `div`s and `inline` for `span`s), you should provide that value inside the options parameter.
 If you want to manually hide the element in situations where the addon is enabled, you should use a dedicated class name for that, instead of manually setting `el.style.display = "none";`. Use a class name selector in a userstyle to set `display: none !important;` on the element.
 
 ### `addon.tab.copyImage`
@@ -266,8 +266,8 @@ If you want to manually hide the element in situations where the addon is enable
     <td>Image could not be copied.</td>
 </table>
 
-Copies a PNG image to the clipboard.  
-Only run this in response of the user explicitly pressing Ctrl+C.  
+Copies a PNG image to the clipboard.
+Only run this in response of the user explicitly pressing Ctrl+C.
 Internally uses `browser.clipboard.setImageData` in Firefox and `navigator.clipboard.write` in Chrome and Edge.
 
 ### `addon.tab.scratchClass`
@@ -339,9 +339,9 @@ Gets the hashed class name for a Scratch stylesheet class name.
   </tr>
 </table>
 
-Gets Scratch translation from the current Scratch tab.  
-Note that these are Scratch locales, not Scratch Addons locales.  
-If the message isn't found, `""` is returned and a warning is logged in the console.  
+Gets Scratch translation from the current Scratch tab.
+Note that these are Scratch locales, not Scratch Addons locales.
+If the message isn't found, `""` is returned and a warning is logged in the console.
 Internally uses `window.django.gettext` or `window._messages`.
 
 ### [`addon.tab.appendToSharedSpace`](addon.tab.appendtosharedspace)
@@ -973,7 +973,7 @@ Removes a block that was previously added to the Debugger category in the block 
   </tr>
 </table>
 
-Runs the specified script file.
+Runs the specified script file relative to the extension's root (e.g. `chrome-extension://aeepldbjfoihffgcaejikpoeppffnlbd/`) in a `<script>` tag.
 
 ### `addon.tab.loadWorker`
 <table>
@@ -1020,6 +1020,6 @@ Loads the specified Web Worker.
   </tr>
 </table>
 
-Fires when Scratch dynamically changes the URL of the page.  
-This happens when going inside/outside the editor, or switching tabs in scratch-www studio pages.  
+Fires when Scratch dynamically changes the URL of the page.
+This happens when going inside/outside the editor, or switching tabs in scratch-www studio pages.
 This will not fire if `location.hash` changed.

--- a/content/docs/reference/addon-api/addon.tab/_index.md
+++ b/content/docs/reference/addon-api/addon.tab/_index.md
@@ -973,7 +973,7 @@ Removes a block that was previously added to the Debugger category in the block 
   </tr>
 </table>
 
-Runs the specified script file.
+Runs the specified script file relative to the extension's root (e.g. `chrome-extension://aeepldbjfoihffgcaejikpoeppffnlbd/`) in a `<script>` tag.
 
 ### `addon.tab.loadWorker`
 <table>


### PR DESCRIPTION
Mostly resolves #438.

For now using `scratchMessage` and `__addon` are only on the best practices page.

I haven't added the enabling a setting behaviour or polluting conflicts to the best practices yet.