### PR TITLE
(v1.39.1) Changes to ChromeWebStore privacy info

### DIFF
--- a/content/docs/policies/chrome-web-store-privacy-information.md
+++ b/content/docs/policies/chrome-web-store-privacy-information.md
@@ -18,37 +18,17 @@ Allows users to customize their experience on the Scratch website (scratch.mit.e
 |-----------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
 | Host permission | Used to access information from, and run content scripts on the Scratch website.                                                        |
 | cookies                     | Used to access the scratchcsrftoken cookie, which needs to be included as an X-CsrfToken header for Scratch API calls.                |
-| webRequest                  | Necessary in order to add an artificial "Referer" header so that requests to the Scratch API from the background page correctly work. |
-| webRequestBlocking          | Necessary in order to add, edit and remove headers before they are sent (see webRequest).                                                                                                                 |
+| webRequest                  | Used to detect 404s through the statusCode property and to precalculate data as soon as onBeforeRequest is fired. |
 | declarativeNetRequestWithHostAccess | Necessary in order to add an artificial "Referer" header so that requests to the Scratch API from the background page correctly work.
 | storage                     | Used to store extension settings.                                                                                                     |
-| contextMenus                | Used to show the "mute for..." feature.  
-| alarms                      | Used for the "mute for..." feature.
+| contextMenus                | Used to show the "do not disturb for X minutes" feature.  
+| alarms                      | Used for the "do not disturb for X minutes" feature.
 
-### Optional Permissions
-| Optional Permission | Justification |
+### Optional permissions
+| Optional permission | Justification |
 | -------------------- | ------------- |
 | notifications | To notify users about new Scratch messages/notifications. |
 
-## Are you using remote code?
-No, I am not using remote code
+## Data usage and Privacy policy
 
-## Data usage
-
-**What user data do you plan to collect from users now or in the future?**
-
-❌ **Personally identifiable information.** For example: name, address, email address, age, or identification number.  
-❌ **Health information.** For example: heart rate data, medical history, symptoms, diagnoses, or procedures.  
-❌ **Financial and payment information.** For example: transactions, credit card numbers, credit ratings, financial statements, or payment history.  
-❌ **Authentication information.** For example: passwords, credentials, security question, or personal identification number (PIN).  
-❌ **Personal communications.** For example: emails, texts, or chat messages.  
-❌ **Location.** For example: region, IP address, GPS coordinates, or information about things near the user’s device.  
-❌ **Web history.** The list of web pages a user has visited, as well as associated data such as page title and time of visit.  
-❌ **User activity.** For example: network monitoring, clicks, mouse position, scroll, or keystroke logging.  
-❌ **Website content.** For example: text, images, sounds, videos, or hyperlinks.
-
-**I certify that the following disclosures are true:**
-
-✔️ I do not sell or transfer user data to third parties, outside of the approved use cases  
-✔️ I do not use or transfer user data for purposes that are unrelated to my item's single purpose  
-✔️ I do not use or transfer user data to determine creditworthiness or for lending purposes
+The extension privacy policy is available at [https://scratchaddons.com/docs/privacy/policies/extension/](https://scratchaddons.com/docs/privacy/policies/extension/).

--- a/content/docs/policies/chrome-web-store-privacy-information.md
+++ b/content/docs/policies/chrome-web-store-privacy-information.md
@@ -18,7 +18,7 @@ Allows users to customize their experience on the Scratch website (scratch.mit.e
 |-----------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
 | Host permission | Used to access information from, and run content scripts on the Scratch website.                                                        |
 | cookies                     | Used to access the scratchcsrftoken cookie, which needs to be included as an X-CsrfToken header for Scratch API calls.                |
-| webRequest                  | Used to detect 404s through the statusCode property and to precalculate data as soon as onBeforeRequest is fired. |
+| webRequest                  | Used to detect 404s through the statusCode property. |
 | declarativeNetRequestWithHostAccess | Necessary in order to add an artificial "Referer" header so that requests to the Scratch API from the background page correctly work.
 | storage                     | Used to store extension settings.                                                                                                     |
 | contextMenus                | Used to show the "do not disturb for X minutes" feature.  


### PR DESCRIPTION
- The webRequestBlocking permission is no longer available in Chrome Manifest V3, so it was removed from the table.
- Updated webRequest justification.
- Updated "mute for..." wording for the new "do not disturb" terminology.
- Removed "no remote code" section as Manifest V3 makes it really hard (and very against the rules!) to run remote code anyways.
- Removed data usage section as it is also available publicly in our Chrome Web Store page.
- Added direct link to the privacy policy - same URL as the one we list in the store.