### PR TITLE
Revert "Add Pre-send warning for 1.38.1 bug"

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -170,10 +170,6 @@ FeedbackPage:
         Heading: We can't punish people. We are not the Scratch Team.
         Description: "Scratch Addons is not affiliated with the Scratch website or the organizations that maintain it. We have no control of the content and the moderation on the Scratch website. {{ .Tag1Start }}There are many ways that you can report on the Scratch website.{{ .Tag1End }}"
 
-      MV3LoadBug:
-        Heading: There is a known issue causing all addons to stop working
-        Description: "Scratch Addons v1.38.1 has a known issue where using some addons may cause all of them to randomly stop working. Try disabling the Necropost Highlighter addon."
-
 # Strings used for /scratch-messaging-transition
 SMTPage:
   ScratchMessagingLogoAlt: Scratch Messaging Extension logo

--- a/layouts/shortcodes/specifics/feedback-form.html
+++ b/layouts/shortcodes/specifics/feedback-form.html
@@ -19,10 +19,6 @@
 					heading: '{{ T "FeedbackPage.PreSendWarning.Variations.Punishment.Heading" }}',
 					description: '{{ T "FeedbackPage.PreSendWarning.Variations.Punishment.Description" ( dict "Tag1Start" (add $ts 1) "Tag1End" (add $ts 2) ) | htmlEscape }}',
 				},
-				MV3LoadBug: {
-					heading: '{{ T "FeedbackPage.PreSendWarning.Variations.MV3LoadBug.Heading" }}',
-					description: '{{ T "FeedbackPage.PreSendWarning.Variations.MV3LoadBug.Description" | htmlEscape }}',
-				}
 			}
 		},
 		submitButton: '{{ T "FeedbackPage.SubmitButton" }}'
@@ -46,4 +42,4 @@
 		<label class="form-check-label" for="feedback-addons-list">{{ T "FeedbackPage.SendEnabled" }}</label>
 	</div>
 	<button class="btn btn-primary" id="feedback-submit" type="button">{{ T "FeedbackPage.SubmitButton" }}</a>
-</form>
+</form>	

--- a/static/assets/js/feedback.js
+++ b/static/assets/js/feedback.js
@@ -29,17 +29,6 @@ const variations = {
             /\bst\b/,
         ]
     },
-    MV3LoadBug: {
-        strings: {
-            ...i18n.preSendWarning.variations.MV3LoadBug
-        },
-        patterns: [
-            /\baddons.*broke(?:n)?\b/,
-            /\bcrash(?:ed|es|ing)?\b/,
-            /\b(do(n't|esn't|\snot)|won't).*(load|work)\b/,
-            /\b(is\snot|isn't|stopped).*(loading|working)\b/,
-        ]
-    },
 }
 
 let lastFeedbackRequestTime = localStorage.getItem("lastFeedbackRequestTime") 


### PR DESCRIPTION
Reverts ScratchAddons/website-v2#450

Version 1.38.2 fixed this issue, so within a few days this pre-send warning doesn't make sense anymore.