### PR TITLE
Add more links of addons on Addons page

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -152,7 +152,14 @@ AddonsPage:
     L2: In this page, an easter egg addon will have an egg symbol besides its name.
   NAddons: "{{.Count}} addons"
   SourceCodeLabel: Source code on GitHub
-
+  SourceCodeLink:
+    Title: Open source code on GitHub
+  SASettingsLink:
+    Label: Settings in Scratch Addons
+    Title: Open in Scratch Addons settings
+  AddonDocsLink:
+    Label: Addon Docs page
+    Title: Read about this addon in Addon Docs
 # Strings used for /feedback
 FeedbackPage:
   Status:

--- a/layouts/shortcodes/specifics/addons.html
+++ b/layouts/shortcodes/specifics/addons.html
@@ -49,7 +49,14 @@
 			{{ if in .tags "easterEgg" }}<span data-toggle="tooltip" title='{{ T "AddonsPage.EasterEggAddon" }}'>🥚</span>{{ end -}}
 			{{ if in .tags "beta" }}<span data-toggle="tooltip" title='{{ T "AddonsPage.BetaAddon" }}'>⚠️</span>{{ end -}}
 		</h5>
-		<h6 class="card-subtitle mb-2 text-muted">{{ .id }} <a href='https://github.com/ScratchAddons/ScratchAddons/tree/master/addons/{{ .id }}' aria-label='{{ T "AddonsPage.SourceCodeLabel" }}' rel="noopener"><span class="iconify-inline" data-icon="simple-icons:github"></span></a></h6>
+		<h6 class="card-subtitle mb-2 text-muted">
+			{{ .id }}
+			<a href='https://github.com/ScratchAddons/ScratchAddons/tree/master/addons/{{ .id }}' title='{{ T "AddonsPage.SourceCodeLink.Title" }}' aria-label='{{ T "AddonsPage.SourceCodeLabel" }}' rel="noopener" data-toggle="tooltip" data-placement="top"><span class="iconify-inline" data-icon="simple-icons:github"></span></a>
+			<a href='https://scratch.mit.edu/scratch-addons-extension/settings#{{ .id }}' title='{{ T "AddonsPage.SASettingsLink.Title" }}' aria-label='{{ T "AddonsPage.SASettingsLink.Label" }}' rel="noopener" data-toggle="tooltip" data-placement="top"><span class="iconify-inline" data-icon="fa-solid:cog"></span></a>
+			{{ if (fileExists (delimit (slice "content/addons/" .id ".md") "")) -}}
+				<a href='./{{ .id }}' title='{{ T "AddonsPage.AddonDocsLink.Title" }}' aria-label='{{ T "AddonsPage.AddonDocsLink.Label" }}' rel="noopener" data-toggle="tooltip" data-placement="top"><span class="iconify-inline" data-icon="fa-solid:book-open"></span></a>
+			{{- end }}
+		</h6>
 		<p class="card-text">{{ .description }}</p>
 	</div>
 </div>


### PR DESCRIPTION
Adds link to the settings on Scratch Addons (settings page) and a link to Addon Docs (if exists) on each addon.

![2024-06-23_14-17-53_firefox](https://github.com/ScratchAddons/website-v2/assets/11584103/afcf2467-a85e-407a-a571-660c8a107ea9)

I'm not sure how to name the settings button fluently and concise. "Open settings in Scratch Addons" seems unclear that this will open on Scratch Addons, "Open addon in Scratch Addons settings" is too long, "Open in Scratch Addons settings" is concise enough, but I'm quite unsure. Perhapse anyone can make it better about it.

Resolves #259