### PR TITLE
Update unsupported-browser.html

### DIFF
--- a/content/unsupported-browser.html
+++ b/content/unsupported-browser.html
@@ -67,7 +67,7 @@ robots_tag: noindex
     System requirements:
     <span class="iconify-inline" data-icon="simple-icons:windows"></span> Windows 7+
     <span class="iconify-inline" data-icon="simple-icons:apple"></span> OS X / MacOS 10.11+
-    <span class="iconify-inline" data-icon="simple-icons:googlechrome"></span> Chromebooks less than ~6 years old
+    <span class="iconify-inline" data-icon="simple-icons:googlechrome"></span> ChromeOS 96+
   </p>
   <br>
   <h4>


### PR DESCRIPTION
Resolves #465

Changes the text on the unsupported-browser page to clearly show the minimum ChromeOS version required.