### PR TITLE
Make it very clear that we are not the Scratch Team on the feedback page

### DIFF
--- a/content/feedback.html
+++ b/content/feedback.html
@@ -9,6 +9,24 @@ description: Send feedback to Scratch Addons developers.
 	<div class="row">
 		<div class="col-12 col-xl-9 mb-4 mb-xl-0">
 			<p>Have something to say about Scratch Addons? Let us know through this feedback form.</p>
+			<p>
+				<strong>NOTE:</strong>
+				This is the feedback page for an <em>unofficial</em> Scratch browser extension
+				<strong>not affiliated with the Scratch Team</strong>!
+				We cannot do anything about moderation actions.
+			</p>
+			<p>
+				If you want to contact the Scratch Team, use the Scratch website's "Contact Us" feature:
+				<a href="https://scratch.mit.edu/contact-us">
+					https://scratch.mit.edu/contact-us
+				</a>
+			</p>
+			<p>
+				If you want to suggest features to be added to vanilla Scratch, use the "Suggestions" forum on the Scratch forums:
+				<a href="https://scratch.mit.edu/discuss/1">
+					https://scratch.mit.edu/discuss/1
+				</a>
+			</p>
 			<hr />
 			{{< specifics/feedback-form >}}
 

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -168,7 +168,7 @@ FeedbackPage:
     Failed: Something went wrong. Try sending again?
     Offline: Something went wrong on the feedback server. Check back later, or use the mentioned alternatives.
   NoAddonsList: The list is not available to be sent. Please open this page through the extension.
-  UsernameLabel: Scratch username, or other identifiers (optional)
+  UsernameLabel: Your Scratch username, or other identifiers (optional)
   ContentLabel: Feedback
   ContentPlaceholder: Please provide as much detail as you can.
   SendEnabled: Send list of my currently enabled addons (recommended)


### PR DESCRIPTION
i am going insane. everyone keeps addressing us as "scratch team", or filling in the username field with the placeholder "ScratchCat", asking us to ban users or unban them or themselves (ok i wrote this in a *sliiiiight* fit of rage)
![image](https://github.com/user-attachments/assets/ff16188b-70ee-4dd0-9a15-6846c6f0442c)
