### PR TITLE
Update references of Twitter to X

### DIFF
--- a/content/feedback.html
+++ b/content/feedback.html
@@ -20,7 +20,7 @@ description: Send feedback to Scratch Addons developers.
 				<li>Create a issue on <a href="https://github.com/ScratchAddons/ScratchAddons/issues" rel="noopener">the repository</a>.</li>
 				<li>Create a post on <a href="https://github.com/ScratchAddons/ScratchAddons/discussions" rel="noopener">our Discussions tab</a></li>
 				<li>Send a message on <a href="https://discord.gg/R5NBqwMjNc" rel="noopener">our Discord server</a></li>
-				<li>Contact one of the contributors on Discord, Twitter, or other methods</li>
+				<li>Contact one of the contributors on Discord, X, or other methods</li>
 			</ul>
 			<p>It is discouraged to contact one of the contributors through Scratch due to <a href="https://scratch.mit.edu/discuss/post/2907564/" rel="noopener">the policy that forbids advertising extensions/userscripts</a>.</p>
 			<p>By the way, we have <a href='{{< ref "/docs/faq" >}}'>a FAQ page</a> for your usual questions.</p>

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -39,7 +39,7 @@ Links:
   DiscordCom: Community Discord
   Discussion: Discussion Forum
   Community: Community
-  Twitter: Twitter
+  Twitter: X
   Reddit: Reddit
 
 # Strings used for the site navigation bar (NEW PAGES SHOULD BE PUT ON "Links" FIELD!)

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -15,7 +15,7 @@
 			<div class="footer-socials">
 				<a href="https://youtube.com/ScratchAddons" aria-label='{{ T "Links.YouTube" }}' rel="noopener" target="_blank"><span class="iconify-inline" data-icon="simple-icons:youtube"></span></a>
 				<a href="https://discord.gg/R5NBqwMjNc" aria-label='{{ T "Links.Discord" }}' rel="noopener" target="_blank"><span class="iconify-inline" data-icon="simple-icons:discord"></span></a>
-				<a href="https://twitter.com/ScratchAddons" aria-label='{{ T "Links.Twitter" }}' rel="noopener" target="_blank"><span class="iconify-inline" data-icon="simple-icons:twitter"></span></a>
+				<a href="https://twitter.com/ScratchAddons" aria-label='{{ T "Links.Twitter" }}' rel="noopener" target="_blank"><span class="iconify-inline" data-icon="simple-icons:x"></span></a>
 				<a href="https://reddit.com/r/ScratchAddons" aria-label='{{ T "Links.Reddit" }}' rel="noopener" target="_blank"><span class="iconify-inline" data-icon="simple-icons:reddit"></span></a>
 				<a href="https://github.com/ScratchAddons" aria-label='{{ T "Links.GitHub" }}' rel="noopener" target="_blank"><span class="iconify-inline" data-icon="simple-icons:github"></span></a>
 			</div>


### PR DESCRIPTION
Resolves #503

Changed references to the Twitter brand to X, to stay up to date.

I know, I know! A lot of us don't like X, but consistency matters, and X doesn't seem to be going away anytime soon.