### PR TITLE
Feedback page: require at least 2 clicks to reach from a search engine

### DIFF
--- a/content/docs/feedback.md
+++ b/content/docs/feedback.md
@@ -1,0 +1,12 @@
+---
+title: Send feedback to Scratch Addons developers
+description: How to send feedback to Scratch Addons.
+weight: 52
+---
+
+This page is to send feedback for an *unofficial* Scratch browser extension **not affiliated with the Scratch Team**!
+We cannot do anything about moderation actions.
+
+If you want to report something on the Scratch website that breaks Scratch's rules, use the Report button on the Scratch website instead.
+
+To send feedback for the Scratch Addons browser extension, visit the Feedback page: https://scratchaddons.com/feedback/

--- a/content/docs/feedback.md
+++ b/content/docs/feedback.md
@@ -4,9 +4,6 @@ description: How to send feedback to Scratch Addons.
 weight: 52
 ---
 
-This page is to send feedback for an *unofficial* Scratch browser extension **not affiliated with the Scratch Team**!
-We cannot do anything about moderation actions.
+**To send feedback for the Scratch Addons browser extension, please visit the Feedback page: https://scratchaddons.com/feedback/**
 
-If you want to report something on the Scratch website that breaks Scratch's rules, use the Report button on the Scratch website instead.
-
-To send feedback for the Scratch Addons browser extension, visit the Feedback page: https://scratchaddons.com/feedback/
+We can't help with issues related to Scratch moderation. Instead, use the Report button on the Scratch website, or reach Scratch through their official channels.

--- a/content/feedback.html
+++ b/content/feedback.html
@@ -1,6 +1,7 @@
 ---
 title: Send Feedback
 description: Send feedback to Scratch Addons developers.
+robots_tag: noindex
 ---
 
 <h1>Send Feedback</h1>


### PR DESCRIPTION
- Add noindex tag to feedback page
- Create new docs page, reachable from search engines, that provides a link to the feedback page, and clarifies we can't help with moderation issues.