### PR TITLE
Update addon manifest docs

### DIFF
--- a/content/docs/reference/addon-manifest.md
+++ b/content/docs/reference/addon-manifest.md
@@ -101,6 +101,11 @@ Addons must have one of these tags. No less than one, no more than one.
     <td>Scratch editor features</td>
   </tr>
   <tr>
+    <td><code>player</code></td>
+    <td>✔️</td>
+    <td>Project player features</td>
+  </tr>
+  <tr>
     <td><code>popup</code></td>
     <td>✔️</td>
     <td>Extension popup features</td>
@@ -135,11 +140,6 @@ Addon authors can usually determine these tags themselves.
     <td><code>costumeEditor</code></td>
     <td>✔️</td>
     <td>Addons that mainly affect the Backdrops/Costumes tab of the editor.</td>
-  </tr>
-  <tr>
-    <td><code>projectPlayer</code></td>
-    <td>✔️</td>
-    <td>Addons that affect the project player in both the website and editor, or that add UI elements above the stage.</td>
   </tr>
   <tr>
     <td><code>editorMenuBar</code></td>
@@ -375,6 +375,7 @@ Sub-properties:
   - `table`: A list of elements, where the user can add custom elements, remove existing ones and change order of them
   - `select`: See `potential_values`
 - `default` (string, required) The default value for the option. A boolean, string, or number, depending on the specified type.  
+- `desciption` (string, optional) The description for the option, shown as a tooltip.
 - `min`/`max` (number, optional for `positive_integer`, `integer`, and `string` types only) For integers, the minimum/maximum value allowed, and for strings, the minimum/maximum allowed length of the value.
 - `potentialValues` (array of objects, required for `select` type only) Array of objects, with properties `id`, the value received from `addon.settings.get()`, and `name`, the user-visible option text.
 - `allowTransparency` (boolean, required for `color` type only) Whether the user should be allowed to enter transparent colors or not.


### PR DESCRIPTION
- Renames the `projectPlayer` tag to `player` and moves it to the required category
- Mention setting descriptions