### PR TITLE
Do not mention a specific contact platform (Discord and Twitter)

### DIFF
--- a/content/docs/getting-started/feedback.md
+++ b/content/docs/getting-started/feedback.md
@@ -21,7 +21,7 @@ In case you need an alternative, here are some choices.
 - Create a issue on [the repository](https://github.com/ScratchAddons/ScratchAddons/issues).
 - Create a post on [our Discussions tab](https://github.com/ScratchAddons/ScratchAddons/discussions)
 - Send a message on [our support Discord server](https://discord.gg/R5NBqwMjNc)
-- Contact one of the contributors on Discord, Twitter, or other methods
+- Contact one of the contributors directly
 
 It is discouraged to contact one of the contributors through Scratch due to [the policy that forbids advertising extensions/userscripts](https://scratch.mit.edu/discuss/post/2907564/).
 

--- a/content/feedback.html
+++ b/content/feedback.html
@@ -21,7 +21,7 @@ robots_tag: noindex
 				<li>Create an issue on <a href="https://github.com/ScratchAddons/ScratchAddons/issues" rel="noopener">the repository</a>.</li>
 				<li>Create a post on <a href="https://github.com/ScratchAddons/ScratchAddons/discussions" rel="noopener">our Discussions tab</a></li>
 				<li>Send a message on <a href="https://discord.gg/R5NBqwMjNc" rel="noopener">our support Discord server</a></li>
-				<li>Contact one of the contributors on Discord, Twitter, or other methods</li>
+				<li>Contact one of the contributors directly</li>
 			</ul>
 			<p>It is discouraged to contact one of the contributors through Scratch due to <a href="https://scratch.mit.edu/discuss/post/2907564/" rel="noopener">the policy that forbids advertising extensions/userscripts</a>.</p>
 			<p>By the way, we have <a href='{{< ref "/docs/faq" >}}'>a FAQ page</a> for your usual questions.</p>


### PR DESCRIPTION
### Changes

Changes the wording of "Contact one of the contributors on Discord, Twitter, or other methods" to "Contact one of the contributors directly".

All other references to Twitter are unchanged.

### Reasons

- Not every contributor is reachable through Discord or Twitter.
- If it was before, Twitter, now X, is probably no longer a preferred direct message method for many people.