### PR TITLE
Fix typos

### DIFF
--- a/content/addons/middle-click-popup.md
+++ b/content/addons/middle-click-popup.md
@@ -15,7 +15,7 @@ The original version was made by Griffpatch for the Developer Tools extension. A
 - When a result is highlighted, you can press tab to autocomplete your search to that block.
 - The popup can insert multiple nested blocks at the same time, by typing something like "move my variable + 10 steps".
 - For mathematical blocks, the order of operations applies by default, but you can use brackets to change the order.
-- You can surround text in double quotes to force the searcher not to turn your text into blocks. This is useful for sitruations like trying to say the text "x position" instead of the variable `x position`, where you could type say "x position".
+- You can surround text in double quotes to force the searcher not to turn your text into blocks. This is useful for situations like trying to say the text "x position" instead of the variable `x position`, where you could type say "x position".
 
 ## Settings
 
@@ -34,7 +34,7 @@ Controls how tall the popup can be before a scrollbar appears. This is a percent
 ## Future plans
 
 - The popup should be resizable by dragging one of the corners in the editor instead of having to change a setting.
-- Adding string interpolation for strings in quotes could really help out situatoins where a lot of join blocks would normally have to be tediously arranged.
+- Adding string interpolation for strings in quotes could really help out situations where a lot of join blocks would normally have to be tediously arranged.
 
 ## Known issues
 

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -235,7 +235,7 @@ AddonDocs:
       Tags: Tags
       VersionAdded: Version added
       LatestUpdate: Latest update
-      Informations: Informations
+      Informations: Information
       FeatureFlags: Feature flags
     LatestUpdate:
       Major: major

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -235,7 +235,7 @@ AddonDocs:
       Tags: Tags
       VersionAdded: Version added
       LatestUpdate: Latest update
-      Informations: Information
+      Information: Information
       FeatureFlags: Feature flags
     LatestUpdate:
       Major: major

--- a/layouts/partials/docs/addons-infobox.html
+++ b/layouts/partials/docs/addons-infobox.html
@@ -57,7 +57,7 @@
 			</td>
 		</tr>{{ end }}
 		{{ with .info }}<tr>
-			<td class="infobox-label">{{ T "AddonDocs.Infobox.Labels.Informations" }}</td>
+			<td class="infobox-label">{{ T "AddonDocs.Infobox.Labels.Information" }}</td>
 			<td class="infobox-data"><ul>
 				<!-- TODO: Do better way to display types -->
 				{{ range . }}


### PR DESCRIPTION
"situations" was misspelled twice on the same page. Also changes "informations" to "information" - the word "information" doesn't have a plural form in English.